### PR TITLE
adjust instance type from m3.medium -> m4.large for f20

### DIFF
--- a/rules/st2_deploy_test_master_f20.yaml
+++ b/rules/st2_deploy_test_master_f20.yaml
@@ -27,4 +27,5 @@
             branch: "{{trigger.parameters.branch}}"
             revision: "{{trigger.parameters.revision}}"
             repo: "{{trigger.parameters.repo}}"
+            instance_type: "m4.large"
             distro: "F20"


### PR DESCRIPTION
This PR adjusts the instance type from `m3.medium` to `m4.large` for Fedora 20 master builds.
## TL;DR

:cloud: I/O is atrociously bad, and Mongo fails to start on initialization. Need moar IO!
## The Breakdown

This AM, `st2_deploy_test` for F20 failed, and based on discussion this is an intermittent error. https://stackstorm.slack.com/archives/stackstorm/p1438777875006245

Further investigation found that the install script failed while attempting to start MongoDB. `systemd` reports that the service failed to start up in a timely manner.

```
[root@st2-master-55c1fd2bfa4bf53656b84a14 ~]# systemctl status mongod.service
mongod.service - High-performance, schema-free document-oriented database
   Loaded: loaded (/usr/lib/systemd/system/mongod.service; enabled)
   Active: failed (Result: timeout) since Wed 2015-08-05 12:31:11 UTC; 2h 49min ago
  Process: 10367 ExecStart=/usr/bin/mongod $OPTIONS run (code=killed, signal=TERM)

Aug 05 12:29:42 st2-master-55c1fd2bfa4bf53656b84a14.uswest2.stackstorm.net mongod[10367]: about to fork child process, waiting until server is ready for connections.
Aug 05 12:29:42 st2-master-55c1fd2bfa4bf53656b84a14.uswest2.stackstorm.net mongod[10367]: forked process: 10369
Aug 05 12:29:42 st2-master-55c1fd2bfa4bf53656b84a14.uswest2.stackstorm.net mongod[10367]: all output going to: /var/log/mongodb/mongodb.log
Aug 05 12:31:11 st2-master-55c1fd2bfa4bf53656b84a14.uswest2.stackstorm.net systemd[1]: mongod.service operation timed out. Terminating.
Aug 05 12:31:11 st2-master-55c1fd2bfa4bf53656b84a14.uswest2.stackstorm.net systemd[1]: Failed to start High-performance, schema-free document-oriented database.
Aug 05 12:31:11 st2-master-55c1fd2bfa4bf53656b84a14.uswest2.stackstorm.net systemd[1]: Unit mongod.service entered failed state.
```

Digging into the MongoDB logs, it appears that `systemd` is just impatient.

```
[root@st2-master-55c1fd2bfa4bf53656b84a14 ~]# cat  /var/log/mongodb/mongodb.log
Wed Aug  5 12:29:42.066 [initandlisten] MongoDB starting : pid=10369 port=27017 dbpath=/var/lib/mongodb 64-bit host=st2-master-55c1fd2bfa4bf53656b84a14.uswest2.stackstorm.net
Wed Aug  5 12:29:42.066 [initandlisten] db version v2.4.6
Wed Aug  5 12:29:42.066 [initandlisten] git version: nogitversion
Wed Aug  5 12:29:42.066 [initandlisten] build info: Linux buildvm-12.phx2.fedoraproject.org 3.10.9-200.fc19.x86_64 #1 SMP Wed Aug 21 19:27:58 UTC 2013 x86_64 BOOST_LIB_VERSION=1_54
Wed Aug  5 12:29:42.066 [initandlisten] allocator: tcmalloc
Wed Aug  5 12:29:42.066 [initandlisten] options: { bind_ip: "127.0.0.1", command: [ "run" ], config: "/etc/mongodb.conf", dbpath: "/var/lib/mongodb", fork: "true", journal: "true", logpath: "/var/log/mongodb/mongodb.log", nohttpinterface: "true", pidfilepath: "/var/run/mongodb/mongodb.pid", port: 27017, quiet: true }
Wed Aug  5 12:29:42.070 [initandlisten] journal dir=/var/lib/mongodb/journal
Wed Aug  5 12:29:42.070 [initandlisten] recover : no journal files present, no recovery needed
Wed Aug  5 12:29:42.322 [initandlisten] preallocateIsFaster=true 3.34
Wed Aug  5 12:29:42.506 [initandlisten] preallocateIsFaster=true 2.04
Wed Aug  5 12:29:43.685 [initandlisten] preallocateIsFaster=true 2.04
Wed Aug  5 12:29:43.685 [initandlisten] preallocating a journal file /var/lib/mongodb/journal/prealloc.0
Wed Aug  5 12:29:46.204 [initandlisten]         File Preallocator Progress: 713031680/1073741824    66%
Wed Aug  5 12:29:49.082 [initandlisten]         File Preallocator Progress: 754974720/1073741824    70%
Wed Aug  5 12:29:52.464 [initandlisten]         File Preallocator Progress: 786432000/1073741824    73%
Wed Aug  5 12:29:55.765 [initandlisten]         File Preallocator Progress: 828375040/1073741824    77%
Wed Aug  5 12:29:58.753 [initandlisten]         File Preallocator Progress: 870318080/1073741824    81%
Wed Aug  5 12:30:01.059 [initandlisten]         File Preallocator Progress: 901775360/1073741824    83%
Wed Aug  5 12:30:04.175 [initandlisten]         File Preallocator Progress: 943718400/1073741824    87%
Wed Aug  5 12:30:07.283 [initandlisten]         File Preallocator Progress: 985661440/1073741824    91%
Wed Aug  5 12:30:23.814 [initandlisten] preallocating a journal file /var/lib/mongodb/journal/prealloc.1
Wed Aug  5 12:30:26.201 [initandlisten]         File Preallocator Progress: 629145600/1073741824    58%
Wed Aug  5 12:30:29.122 [initandlisten]         File Preallocator Progress: 754974720/1073741824    70%
Wed Aug  5 12:30:32.166 [initandlisten]         File Preallocator Progress: 880803840/1073741824    82%
Wed Aug  5 12:30:35.064 [initandlisten]         File Preallocator Progress: 996147200/1073741824    92%
Wed Aug  5 12:30:52.716 [initandlisten] preallocating a journal file /var/lib/mongodb/journal/prealloc.2
Wed Aug  5 12:30:55.089 [initandlisten]         File Preallocator Progress: 650117120/1073741824    60%
Wed Aug  5 12:30:58.007 [initandlisten]         File Preallocator Progress: 775946240/1073741824    72%
Wed Aug  5 12:31:01.232 [initandlisten]         File Preallocator Progress: 901775360/1073741824    83%
Wed Aug  5 12:31:04.198 [initandlisten]         File Preallocator Progress: 1017118720/1073741824   94%
Wed Aug  5 12:31:11.853 [signalProcessingThread] got signal 15 (Terminated), will terminate after current cmd ends
Wed Aug  5 12:31:12.256 [signalProcessingThread] now exiting
Wed Aug  5 12:31:12.860 dbexit:
Wed Aug  5 12:31:12.860 [signalProcessingThread] shutdown: going to close listening sockets...
Wed Aug  5 12:31:13.037 [signalProcessingThread] shutdown: going to flush diaglog...
Wed Aug  5 12:31:13.037 [signalProcessingThread] shutdown: going to close sockets...
Wed Aug  5 12:31:13.037 [signalProcessingThread] shutdown: waiting for fs preallocator...
Wed Aug  5 12:31:13.037 [signalProcessingThread] shutdown: lock for final commit...
Wed Aug  5 12:31:13.037 [signalProcessingThread] shutdown: final commit...
Wed Aug  5 12:31:13.065 [signalProcessingThread] shutdown: closing all files...
Wed Aug  5 12:31:13.153 [signalProcessingThread] closeAllFiles() finished
Wed Aug  5 12:31:13.153 [signalProcessingThread] journalCleanup...
Wed Aug  5 12:31:13.153 [signalProcessingThread] removeJournalFiles
Wed Aug  5 12:31:13.810 [signalProcessingThread] shutdown: removing fs lock...
Wed Aug  5 12:31:13.813 dbexit: really exiting now
```

What this boils down to is I/O being intermittently bad on the cloud node, and causing the MongoDB journal to not be allocated fast enough for SystemD to be happy. And then everything goes downhill from there. This change allocates a newer class of machine in AWS with faster CPU and SSD, so we can give it a shot to remove false positives from the pipeline.
