### PR TITLE
Fix git actions

### DIFF
--- a/actions/git_clean.sh
+++ b/actions/git_clean.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+REPO=$1
+REPO_DIR=$2
+ALT_REPO=$REPO_DIR/$REPO
+
+if [[ ! -d $REPO ]]; then
+    echo "$REPO does not exist. Trying $ALT_REPO."
+
+    if [[ ! -d $ALT_REPO ]]; then
+        echo "$ALT_REPO does not exist."
+        exit 0
+    else
+        REPO=$ALT_REPO
+    fi
+fi
+
+echo "Removing $REPO..."
+rm -Rf $REPO
+
+if [[ -d $REPO ]]; then
+    echo "Unable to remove $REPO."
+    exit 1
+else
+    echo "$REPO deleted."
+fi

--- a/actions/git_clean.yaml
+++ b/actions/git_clean.yaml
@@ -1,20 +1,24 @@
 ---
   name: "git_clean"
-  runner_type: "run-remote"
-  description: "Clean a git repo"
+  runner_type: "remote-shell-script"
+  description: "Remove clone of git repo"
   enabled: true
-  entry_point: ""
-  parameters: 
-    sudo: 
+  entry_point: "git_clean.sh"
+  parameters:
+    repo:
+      type: string
+      required: true
+      position: 0
+    repo_dir:
+      type: string
+      default: "{{dir}}"
+      position: 1
+    sudo:
       immutable: true
       default: false
-    repo:
-      required: true
-      default: "master"
-    cmd: 
-      immutable: false
-      default: "rm -Rf {{dir}}/{{repo}} && echo '{{repo}} deleted'"
-    kwarg_op: 
+    cmd:
+      immutable: true
+      default: ""
+    kwarg_op:
       immutable: true
       default: "--"
-

--- a/actions/git_clone.sh
+++ b/actions/git_clone.sh
@@ -8,7 +8,8 @@ BRANCH=$3
 
 if [[ -d $TARGET ]]
 then
-    echo $TARGET
+    # Use printf so a newline character is not included.
+    printf $TARGET
     exit 0
 fi
 
@@ -16,7 +17,8 @@ GITOUTPUT=`$GIT clone -b ${BRANCH} --single-branch $REPO $TARGET`
 
 if [[ $? == 0 ]]
 then
-  echo $TARGET
+  # Use printf so a newline character is not included.
+  printf $TARGET
 else
   echo $GITOUTPUT
   exit 1


### PR DESCRIPTION
git_clone returns

```
id: 55d268f81e2e244f813a760d
status: succeeded
result: 
{
    "wcchan-itest001.uswest2.stackstorm.net": {
        "succeeded": true, 
        "failed": false, 
        "return_code": 0, 
        "stderr": "Cloning into '/home/stanley/mistral_master_1439853119_20741'...
", 
        "stdout": "/home/stanley/mistral_master_1439853119_20741"
    }
}
```

instead of (a newline \n char at end of stdout)

```
id: 55d268f81e2e244f813a760d
status: succeeded
result: 
{
    "wcchan-itest001.uswest2.stackstorm.net": {
        "succeeded": true, 
        "failed": false, 
        "return_code": 0, 
        "stderr": "Cloning into '/home/stanley/mistral_master_1439853119_20741'...
", 
        "stdout": "/home/stanley/mistral_master_1439853119_20741
"
    }
}
```

git_clean previously assumes the repo is at dir and appends repo to dir. This change allows repo to be somewhere else.

```
st2 run st2cd.git_clean hosts=foobar repo=/path/to/my/repo
```
