### PR TITLE
Reduce noise on ChatOps workflowsl

### DIFF
--- a/actions/create_vm_role.meta.yaml
+++ b/actions/create_vm_role.meta.yaml
@@ -58,3 +58,16 @@
       description: "used by rule with actiontrigger"
       immutable: true
       default: "slack"
+  skip_notify:
+    default:
+      - get_subnet_id
+      - get_ami
+      - run_instance
+      - wait_for_instance
+      - wait_for_ssh
+      - add_name_tag
+      - add_cname
+      - set_hostname
+      - reboot
+      - wait_for_ssh_post_reboot
+      - puppet_bootstrap

--- a/actions/destroy_vm.meta.yaml
+++ b/actions/destroy_vm.meta.yaml
@@ -27,3 +27,10 @@
       description: "used by rule with actiontrigger"
       immutable: true
       default: "slack"
+  skip_notify:
+    default:
+      - get_instance_dns
+      - get_instances
+      - id
+      - destroy_vm
+      - delete_cname


### PR DESCRIPTION
This PR reduces noise for a few of the workflows that are used in ChatOps. Namely:
- `st2cd.create_vm_role`
- `st2cd.destroy_vm`.

I'm not a fan of how tightly coupled the action meta now is to the workflow itself, but this is what we have.
