### PR TITLE
Revert "Reduce noise on ChatOps workflowsl"

### DIFF
--- a/actions/create_vm_role.meta.yaml
+++ b/actions/create_vm_role.meta.yaml
@@ -58,16 +58,3 @@
       description: "used by rule with actiontrigger"
       immutable: true
       default: "slack"
-  skip_notify:
-    default:
-      - get_subnet_id
-      - get_ami
-      - run_instance
-      - wait_for_instance
-      - wait_for_ssh
-      - add_name_tag
-      - add_cname
-      - set_hostname
-      - reboot
-      - wait_for_ssh_post_reboot
-      - puppet_bootstrap

--- a/actions/destroy_vm.meta.yaml
+++ b/actions/destroy_vm.meta.yaml
@@ -27,10 +27,3 @@
       description: "used by rule with actiontrigger"
       immutable: true
       default: "slack"
-  skip_notify:
-    default:
-      - get_instance_dns
-      - get_instances
-      - id
-      - destroy_vm
-      - delete_cname


### PR DESCRIPTION
Reverts StackStorm/st2cd#15

```
On instance:
    {'description': 'Create a VM, add DNS, bootstrap puppet',
     'enabled': True,
     'entry_point': 'workflows/create_vm_role.yaml',
     'name': 'create_vm_role',
     'pack': 'st2cd',
     'parameters': {'base_user': {'default': 'ubuntu',
                                  'description': 'Username for initial ssh test',
                                  'type': 'string'},
                    'distro': {'default': 'UBUNTU14',
                               'enum': ['RHEL6',
                                        'RHEL7',
                                        'F20',
                                        'F21',
                                        'UBUNTU14']},
                    'dns_zone': {'default': 'uswest2.stackstorm.net',
                                 'description': 'Route53 DNS Zone to add host to',
                                 'type': 'string'},
                    'environment': {'default': 'staging',
                                    'description': 'Environment to deploy to',
                                    'enum': ['production',
                                             'staging',
                                             'sandbox'],
                                    'type': 'string'},
                    'hostname': {'description': 'Short hostname',
                                 'required': True,
                                 'type': 'string'},
                    'instance_type': {'default': 't2.medium',
                                      'description': 'Flavor of to use for instance creation',
                                      'type': 'string'},
                    'key_name': {'default': 'st2_deploy',
                                 'description': 'SSH key to use during intial instance creation',
                                 'type': 'string'},
                    'keyfile': {'default': '/home/stanley/.ssh/stanley_rsa',
                                'description': 'Path to local private key that corresponds to {{key_name}}',
                                'type': 'string'},
                    'notification': {'default': 'slack',
                                     'description': 'used by rule with actiontrigger',
                                     'immutable': True,
                                     'type': 'string'},
                    'notification_channel': {'default': '#opstown',
                                             'description': 'used by rule with actiontrigger',
                                             'immutable': True,
                                             'type': 'string'},
                    'role': {'description': 'Role to use during puppet apply',
                             'type': 'string'}},
     'runner_type': 'action-chain',
     'skip_notify': {'default': ['get_subnet_id',
                                 'get_ami',
                                 'run_instance',
                                 'wait_for_instance',
                                 'wait_for_ssh',
                                 'add_name_tag',
                                 'add_cname',
                                 'set_hostname',
                                 'reboot',
                                 'wait_for_ssh_post_reboot',
                                 'puppet_bootstrap']}}
2015-08-18 23:53:25,622 ERROR [-] Unable to register action: /opt/stackstorm/packs/st2cd/actions/destroy_vm.meta.yaml
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/st2actions/bootstrap/actionsregistrar.py", line 145, in _register_actions_from_pack
    self._register_action(pack, action)
  File "/usr/lib/python2.7/dist-packages/st2actions/bootstrap/actionsregistrar.py", line 118, in _register_action
    action_api.validate()
  File "/usr/lib/python2.7/dist-packages/st2common/models/api/base.py", line 64, in validate
    VALIDATOR(getattr(self, 'schema', {})).validate(vars(self))
  File "/usr/local/lib/python2.7/dist-packages/jsonschema/validators.py", line 117, in validate
    raise error
ValidationError: Additional properties are not allowed ('skip_notify' was unexpected)
```

/cc @lakshmi-kannan @manasdk 
