### PR TITLE
increase timeout of puppet runs to 10 minutes

### DIFF
--- a/actions/puprun.yaml
+++ b/actions/puprun.yaml
@@ -24,3 +24,5 @@
     kwarg_op:
       immutable: true
       default: "--"
+    timeout:
+      default: 600


### PR DESCRIPTION
This PR increases the runtime of a puppet converge from 60 seconds to 10 minutes.
