### PR TITLE
Release pipeline fixes

### DIFF
--- a/actions/create_version_release_st2client_rule.py
+++ b/actions/create_version_release_st2client_rule.py
@@ -89,7 +89,7 @@ def main(args):
         'action': {
             'ref': 'st2cd.st2_pkg_st2client',
             'parameters': {
-                'repo': '{{trigger.body.repository.clone_url}}',
+                'repo': '{{trigger.parameters.repo}}',
                 'branch': args.branch
             }
         }

--- a/actions/create_version_tag_rule.py
+++ b/actions/create_version_tag_rule.py
@@ -80,6 +80,10 @@ def main(args):
             'trigger.parameters.environment': {
                 'pattern': 'production',
                 'type': 'equals'
+            },
+            'trigger.status': {
+                'pattern': 'succeeded',
+                'type': 'equals'
             }
         },
         'action': {

--- a/rules/webui_pkg_prod.yaml
+++ b/rules/webui_pkg_prod.yaml
@@ -14,9 +14,6 @@
         trigger.parameters.environment:
             pattern: "production"
             type: "equals"
-        trigger.parameters.distro:
-            pattern: "UBUNTU14"
-            type: "equals"
     action:
         ref: "st2cd.webui_pkg"
         parameters:


### PR DESCRIPTION
1) Fix st2client release rule - actiontrigger and specifically on that action provide repo in parameters. The prvious would've worked with a git postcommit hook most likely.

2) st2cd.st2_pkg_ubuntu14 does not have distro parameter - Likely a relic from deploy_test or something where distro is supplied
