### PR TITLE
Adding rhel pkg rules

### DIFF
--- a/rules/st2_pkg_staging_el6.yaml
+++ b/rules/st2_pkg_staging_el6.yaml
@@ -1,0 +1,23 @@
+---
+    name: "st2_pkg_staging_el6"
+    description: "Build st2 packages after tests succeed and push them to staging"
+    enabled: true
+    trigger:
+        type: "core.st2.generic.actiontrigger"
+    criteria:
+        trigger.action_name:
+            pattern: "st2cd.pytests"
+            type: "equals"
+        trigger.status:
+            pattern: "succeeded"
+            type: "equals"
+    action:
+        ref: "st2cd.st2_pkg_el"
+        parameters:
+            repo: "{{trigger.parameters.repo}}"
+            branch: "{{trigger.parameters.branch}}"
+            dl_server: "{{system.yum_origin_staging}}"
+            environment: "staging"
+            revision: "{{trigger.parameters.revision}}"
+            build: "{{trigger.result.tasks[1].result.result.value}}"
+            distro_release: "6"

--- a/rules/st2_pkg_staging_el7.yaml
+++ b/rules/st2_pkg_staging_el7.yaml
@@ -1,0 +1,23 @@
+---
+    name: "st2_pkg_staging_el7"
+    description: "Build st2 packages after tests succeed and push them to staging"
+    enabled: true
+    trigger:
+        type: "core.st2.generic.actiontrigger"
+    criteria:
+        trigger.action_name:
+            pattern: "st2cd.pytests"
+            type: "equals"
+        trigger.status:
+            pattern: "succeeded"
+            type: "equals"
+    action:
+        ref: "st2cd.st2_pkg_el"
+        parameters:
+            repo: "{{trigger.parameters.repo}}"
+            branch: "{{trigger.parameters.branch}}"
+            dl_server: "{{system.yum_origin_staging}}"
+            environment: "staging"
+            revision: "{{trigger.parameters.revision}}"
+            build: "{{trigger.result.tasks[1].result.result.value}}"
+            distro_release: "7"


### PR DESCRIPTION
This PR adds two rules to fire RHEL6 and RHEL7 packaging directly after pytests succeeds.
