### PR TITLE
Automatically re-generate README.md in st2contrib on push to master

### DIFF
--- a/actions/st2contrib_regenerate_readme.meta.yaml
+++ b/actions/st2contrib_regenerate_readme.meta.yaml
@@ -1,0 +1,29 @@
+---
+  name: "st2contrib_regenerate_readme"
+  runner_type: "action-chain"
+  description: "Regenerate README.md in st2contrib repo and push changes upstream"
+  enabled: true
+  entry_point: "workflows/workflows/st2contrib_regenerate_readme.yaml"
+  parameters:
+    repo:
+      type: "string"
+      description: "Url of the repo to clone"
+      default: "https://github.com/StackStorm/st2contrib.git"
+      required: true
+    branch:
+      type: "string"
+      description: "The branch to use"
+      default: "master"
+      required: true
+    repo_target:
+      type: "string"
+      description: "Directory where to clone the repo."
+      default: "st2contrib_master"
+    revision:
+      type: "string"
+      description: "Pushed revision."
+      required: true
+    author:
+      type: "string"
+      description: "Author of the pushed revision."
+      required: true

--- a/actions/st2contrib_regenerate_readme.meta.yaml
+++ b/actions/st2contrib_regenerate_readme.meta.yaml
@@ -3,7 +3,7 @@
   runner_type: "action-chain"
   description: "Regenerate README.md in st2contrib repo and push changes upstream"
   enabled: true
-  entry_point: "workflows/workflows/st2contrib_regenerate_readme.yaml"
+  entry_point: "workflows/st2contrib_regenerate_readme.yaml"
   parameters:
     repo:
       type: "string"

--- a/actions/workflows/st2contrib_regenerate_readme.yaml
+++ b/actions/workflows/st2contrib_regenerate_readme.yaml
@@ -1,0 +1,55 @@
+---
+  chain:
+    -
+      name: "get_build_server"
+      ref: "linux.dig"
+      params:
+        hostname: "st2-build-slave-ubuntu.service.consul"
+        rand: true
+        count: 1
+      publish:
+        build_server: "{{get_build_server.result[0]}}"
+      on-success: "git_clone_repo"
+    -
+      name: "git_clone_repo"
+      ref: "st2cd.git_clone"
+      params:
+        hosts: "{{build_server}}"
+        repo: "{{repo}}"
+        branch: "{{branch}}"
+        target: "{{repo_target}}"
+      publish:
+        repo_dir: "{{git_clone_repo[build_server].stdout}}"
+      on-success: "regenerate_readme"
+    -
+      name: "regenerate_readme"
+      ref: "core.remote"
+      params:
+        hosts: "{{build_server}}"
+        cwd: "{{repo_dir}}"
+        cmd: "python scripts/update-readme-with-pack-list.py"
+      on-success: "git_commit_changes"
+    -
+      name: "git_commit_changes"
+      ref: "st2cd.git_commit_changes"
+      params:
+        repo: "{{repo_dir}}"
+        branch: "{{branch}}"
+        commit_msg: "\"Re-generate README.md\""
+        hosts: "{{build_server}}"
+      on-success: "push_changes_to_remote"
+    -
+      name: "push_changes_to_remote"
+      ref: "st2cd.git_push_branch"
+      params:
+        repo: "{{repo_dir}}"
+        branch: "{{branch}}"
+        hosts: "{{build_server}}"
+      on-success: "git_clean_repo"
+      on-failure: "git_clean_repo"
+    -
+      name: "git_clean_repo"
+      ref: "st2cd.git_clean"
+      params:
+        hosts: "{{build_server}}"
+        repo: "{{repo_dir}}"

--- a/actions/workflows/st2contrib_regenerate_readme.yaml
+++ b/actions/workflows/st2contrib_regenerate_readme.yaml
@@ -38,6 +38,7 @@
         commit_msg: "\"Re-generate README.md\""
         hosts: "{{build_server}}"
       on-success: "push_changes_to_remote"
+      on-failure: "git_clean_repo"
     -
       name: "push_changes_to_remote"
       ref: "st2cd.git_push_branch"

--- a/rules/st2contrib_regenerate_readme.yaml
+++ b/rules/st2contrib_regenerate_readme.yaml
@@ -1,0 +1,20 @@
+---
+    name: "st2contrib_regenerate_readme"
+    description: "Re-generate README.md on push to master in st2contrib"
+    enabled: true
+    trigger:
+        type: "webhooks.github_event"
+    criteria:
+        trigger.body.ref:
+            pattern: "refs/heads/master"
+            type: "equals"
+        trigger.body.repository.full_name:
+            pattern: "StackStorm/st2contrib"
+            type: "equals"
+    action:
+        ref: "st2cd.st2contrib_regenerate_readme"
+        parameters:
+            repo: "{{trigger.body.repository.clone_url}}"
+            branch: "master"
+            revision: "{{trigger.body.head_commit.id}}"
+            author: "{{trigger.body.head_commit.author.username}}"


### PR DESCRIPTION
I've been doing this manually for far too long.

This pull request automates that.
