### PR TITLE
Install webui pack as part of e2e tests

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -30,6 +30,13 @@
       params:
         hosts: "{{hostname}}"
         pack: "tests"
+      on-success: "install_webui"
+    -
+      name: "install_webui"
+      ref: "st2cd.install_tests"
+      params:
+        hosts: "{{hostname}}"
+        pack: "webui"
       on-success: "install_examples"
     -
       name: "install_examples"
@@ -187,7 +194,7 @@
         hosts: "{{hostname}}"
         timeout: 600
       on-success: "test_windows_runners"
-      on-failure: "test_windows_runners"      
+      on-failure: "test_windows_runners"
     -
       name: "test_windows_runners"
       ref: "st2cd.action_run"


### PR DESCRIPTION
To fix this build failure.

```
lakshmi@st2build002:~$ st2 execution get 560acfc182fb9b3299312a00
id: 560acfc182fb9b3299312a00
action.ref: st2cd.e2e_tests
status: failed
error: Failed to run task "selenium". Action with reference "webui.selenium" doesn't exist.
traceback: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/st2actions/runners/actionchainrunner.py", line 201, in run
    action_params=action_parameters, context_result=context_result)
  File "/usr/lib/python2.7/dist-packages/st2actions/runners/actionchainrunner.py", line 358, in _get_next_action
    raise InvalidActionReferencedException(error)
InvalidActionReferencedException: Task :: selenium - Action with ref webui.selenium not registered.

start_timestamp: 2015-09-29T17:52:01.026487Z
end_timestamp: 2015-09-29T18:01:13.206772Z
+--------------------------+-----------+--------------------------------+------------------------+-------------------------------+
| id                       | status    | task                           | action                 | start_timestamp               |
+--------------------------+-----------+--------------------------------+------------------------+-------------------------------+
| 560acfc182fb9b32a2e97bac | succeeded | get_st2_token                  | st2cd.get_st2_token    | Tue, 29 Sep 2015 17:52:01 UTC |
| 560acfc482fb9b32a2e97bae | succeeded | install_fixtures               | st2cd.install_tests    | Tue, 29 Sep 2015 17:52:04 UTC |
| 560acfd482fb9b32a2e97bb0 | succeeded | install_asserts                | st2cd.install_tests    | Tue, 29 Sep 2015 17:52:20 UTC |
| 560acfe182fb9b32a2e97bb2 | succeeded | install_tests                  | st2cd.install_tests    | Tue, 29 Sep 2015 17:52:33 UTC |
| 560acfea82fb9b32a2e97bb4 | succeeded | install_examples               | st2cd.install_examples | Tue, 29 Sep 2015 17:52:42 UTC |
| 560acff382fb9b32a2e97bb7 | succeeded | core_local_date                | st2cd.action_run       | Tue, 29 Sep 2015 17:52:51 UTC |
| 560acff682fb9b32a2e97bb9 | succeeded | core_http_google               | st2cd.action_run       | Tue, 29 Sep 2015 17:52:54 UTC |
| 560acffa82fb9b32a2e97bbb | succeeded | core_remote_single_host        | st2cd.action_run       | Tue, 29 Sep 2015 17:52:58 UTC |
| 560ad00082fb9b32a2e97bbd | succeeded | test_quickstart                | st2cd.action_run       | Tue, 29 Sep 2015 17:53:04 UTC |
| 560ad02282fb9b32a2e97bc0 | succeeded | test_quickstart_key            | st2cd.action_run       | Tue, 29 Sep 2015 17:53:38 UTC |
| 560ad02a82fb9b32a2e97bc2 | succeeded | test_quickstart_rules          | st2cd.action_run       | Tue, 29 Sep 2015 17:53:46 UTC |
| 560ad05982fb9b32a2e97bc4 | succeeded | test_quickstart_packs          | st2cd.action_run       | Tue, 29 Sep 2015 17:54:33 UTC |
| 560ad0d082fb9b32a2e97bc7 | succeeded | test_quickstart_local_script   | st2cd.action_run       | Tue, 29 Sep 2015 17:56:32 UTC |
| 560ad0e682fb9b32a2e97bc9 | succeeded | test_quickstart_remote_script  | st2cd.action_run       | Tue, 29 Sep 2015 17:56:54 UTC |
| 560ad10c82fb9b32a2e97bcb | succeeded | test_quickstart_passive_sensor | st2cd.action_run       | Tue, 29 Sep 2015 17:57:32 UTC |
| 560ad11982fb9b32a2e97bcd | succeeded | test_quickstart_polling_sensor | st2cd.action_run       | Tue, 29 Sep 2015 17:57:45 UTC |
| 560ad12382fb9b32a2e97bcf | succeeded | test_quickstart_python         | st2cd.action_run       | Tue, 29 Sep 2015 17:57:55 UTC |
| 560ad13a82fb9b32a2e97bd2 | succeeded | test_mistral_examples          | st2cd.action_run       | Tue, 29 Sep 2015 17:58:18 UTC |
| 560ad1db82fb9b32a2e97bd4 | failed    | test_timer_rule                | st2cd.action_run       | Tue, 29 Sep 2015 18:00:59 UTC |
| 560ad1e382fb9b32a2e97bd6 | failed    | test_windows_runners           | st2cd.action_run       | Tue, 29 Sep 2015 18:01:07 UTC |
+--------------------------+-----------+--------------------------------+------------------------+-------------------------------+
lakshmi@st2build002:~$
```
