### PR TITLE
Make hosts optional for the mistral release candidate workflow

### DIFF
--- a/actions/mistral_release_candidate.yaml
+++ b/actions/mistral_release_candidate.yaml
@@ -5,18 +5,18 @@ enabled: true
 runner_type: mistral-v2
 entry_point: workflows/mistral_release_candidate.yaml
 parameters:
-  test_host:
-    type: string
-    description: The name of the hosts where the integration test(s) will run.
-    required: true
-  build_host:
-    type: string
-    description: The name of the hosts where the build process will run.
-    required: true
   version:
     type: string
     description: The release version major.minor.patch.
     required: true
+  test_host:
+    type: string
+    description: The name of the hosts where the integration test(s) will run.
+    default: None
+  build_host:
+    type: string
+    description: The name of the hosts where the build process will run.
+    default: None
   mis_repo_main:
     type: string
     default: git@github.com:StackStorm/mistral.git

--- a/actions/workflows/mistral_release_candidate.yaml
+++ b/actions/workflows/mistral_release_candidate.yaml
@@ -7,9 +7,9 @@ workflows:
     main:
         type: direct
         input:
+            - version
             - test_host
             - build_host
-            - version
             - mis_repo_main
             - mis_repo_client
             - mis_repo_action


### PR DESCRIPTION
If hosts is not provided, then the WF will use linux.dig to identify the build and test hosts to use.
