### PR TITLE
RFR: Handle add_ci_user for different distros

### DIFF
--- a/actions/add_ci_user.sh
+++ b/actions/add_ci_user.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+USERNAME=${1}
+PASSWORD=${2}
+DISTRO=${3}
+SALT=${4}
+
+if [ -z ${SALT} ]
+then
+  SALT='mkpasswd'
+fi
+
+if [ -z "${USERNAME}" ]
+then
+  echo "USERNAME required to created user."
+  exit 1
+fi
+
+if [ -z "${PASSWORD}" ]
+then
+  echo "PASSWORD required to created user."
+  exit 2
+fi
+
+if [ -z "${DISTRO}" ]
+then
+  echo "DISTRO required."
+  exit 3
+fi
+
+if [[ "$DISTRO" = UBUNTU* ]]
+then
+  useradd ${USERNAME} -p `mkpasswd --method=sha-512 $PASSWORD ${SALT}`
+elif [[ "$DISTRO" = RHEL* ]]
+then
+  echo "Created user ${USERNAME}."
+  sha512_pass=$(python -c "import crypt; print crypt.crypt('${PASSWORD}', '\$6\$${SALT}\$')")
+  useradd ${USERNAME} -p ${sha512_pass}
+else
+  echo "Unsupported distro ${DISTRO}."
+fi

--- a/actions/add_ci_user.yaml
+++ b/actions/add_ci_user.yaml
@@ -1,0 +1,38 @@
+---
+  name: "add_ci_user"
+  runner_type: "run-remote-script"
+  description: "Add a user to box"
+  enabled: true
+  entry_point: "add_ci_user.sh"
+  parameters:
+    user:  # Don't use ``username``. It's reserved for runner.
+      type: "string"
+      description: "Username for login."
+      required: true
+      position: 0
+    pass:  # Don't use ``password``. It's reserved for runner.
+      type: "string"
+      description: "Password for login."
+      required: true
+      position: 1
+    distro:
+      type: "string"
+      description: "Distro info. E.g. UBUNTU, RHEL"
+      required: true
+      position: 2
+      default: "UBUNTU"
+    salt:
+      type: "string"
+      description: "Password salt"
+      required: false
+      position: 3
+      default: "mkpasswd"
+    sudo:
+      immutable: true
+      default: true
+    cmd:
+      immutable: true
+      default: ""
+    kwarg_op:
+      immutable: true
+      default: "--"

--- a/actions/workflows/st2workroom_test.yaml
+++ b/actions/workflows/st2workroom_test.yaml
@@ -15,6 +15,8 @@
         keyfile: "{{keyfile}}"
         distro: "{{distro}}"
         role: "{{role}}"
+      publish:
+        distro: "{{distro}}"
       on-success: "delete_existing_puppet"
     -
       name: "delete_existing_puppet"
@@ -48,10 +50,12 @@
       on-success: "add_ci_user"
     -
       name: "add_ci_user"
-      ref: "core.remote_sudo"
+      ref: "st2cd.add_ci_user"
       params:
         hosts: "{{hostname}}"
-        cmd: "useradd {{st2_username}} -p `mkpasswd {{st2_password}}`"
+        distro: "{{distro}}"
+        user: "{{st2_username}}"
+        pass: "{{st2_password}}"
       on-success: "run_tests"
     -
       name: "run_tests"


### PR DESCRIPTION
Tested script on different distros. 

Note:

`mkpasswd` is completely different on Ubuntu vs RHEL. Same story with `passwd`. Unfortunately, unless a fixed salt is provided, mkpasswd produces a different hash every time. In theory, we could use a different salt every time. Script is flexible enough to do that but I tested with a fixed salt. So let's stick to it. 

```
/m/s/s/st2cd git:master ❯❯❯ sudo actions/add_ci_user.sh test password UBUNTU                                                                                                                                                    ✭ ✱ ◼
/m/s/s/st2cd git:master ❯❯❯ sudo cat /etc/shadow | grep test                                                                                                                                                                    ✭ ✱ ◼
test:$6$mkpasswd$XylH4UzQ74hEQgZ3Zn1oQiLEXk5Pk3.YD/7GiBeyXmwOAnBprKY6dKzrdIUkvQDl6G2Itpb0dCOxdFWSP0wmu.:16713:0:99999:7:::
/m/s/s/st2cd git:master ❯❯❯
```

```
[root@st2w-master-el6-560f77c782fb9b0bb51dddb1 lakshmi]# ./add_ci_user.sh test password RHEL
Created user test.
[root@st2w-master-el6-560f77c782fb9b0bb51dddb1 lakshmi]# cat /etc/shadow | grep test
test:$6$mkpasswd$XylH4UzQ74hEQgZ3Zn1oQiLEXk5Pk3.YD/7GiBeyXmwOAnBprKY6dKzrdIUkvQDl6G2Itpb0dCOxdFWSP0wmu.:16713:0:99999:7:::
[root@st2w-master-el6-560f77c782fb9b0bb51dddb1 lakshmi]#
```

```
[root@st2w-master-el7-560f77c782fb9b0bb51dddb3 lakshmi]# ./add_ci_user.sh test password RHEL
Created user test.
[root@st2w-master-el7-560f77c782fb9b0bb51dddb3 lakshmi]# cat /etc/shadow | grep test
test:$6$mkpasswd$XylH4UzQ74hEQgZ3Zn1oQiLEXk5Pk3.YD/7GiBeyXmwOAnBprKY6dKzrdIUkvQDl6G2Itpb0dCOxdFWSP0wmu.:16713:0:99999:7:::
[root@st2w-master-el7-560f77c782fb9b0bb51dddb3 lakshmi]#
```
