### PR TITLE
Repo param is {{repodir}}

### DIFF
--- a/actions/workflows/st2_pytests.yaml
+++ b/actions/workflows/st2_pytests.yaml
@@ -43,7 +43,7 @@
       ref: "st2cd.pytests_split"
       params:
         build_server: "{{build_server}}"
-        repo_target: "{{repo_target}}"
+        repo_target: "{{repodir}}"
       on-success: "upload_coverage_report"
     -
       name: "upload_coverage_report"


### PR DESCRIPTION
```
root@st2build002:/home/lakshmi# st2 execution get 5618115c82fb9b500aef82ee
id: 5618115c82fb9b500aef82ee
action.ref: st2cd.pytests
status: running
start_timestamp: 2015-10-09T19:11:24.885447Z
end_timestamp: None
+-----------------------------+-----------+---------------------+---------------------+---------------------+
| id                          | status    | task                | action              | start_timestamp     |
+-----------------------------+-----------+---------------------+---------------------+---------------------+
|   5618115d82fb9b5001400f87  | succeeded | get_current_build   | st2cd.kvstore       | Fri, 09 Oct 2015    |
|                             |           |                     |                     | 19:11:25 UTC        |
|   5618115e82fb9b5001400f89  | succeeded | build_inc           | st2cd.kvstore       | Fri, 09 Oct 2015    |
|                             |           |                     |                     | 19:11:26 UTC        |
|   5618115f82fb9b5001400f8b  | succeeded | get_build_server    | linux.dig           | Fri, 09 Oct 2015    |
|                             |           |                     |                     | 19:11:27 UTC        |
|   5618116082fb9b5001400f8d  | succeeded | clone_repo          | st2cd.git_clone     | Fri, 09 Oct 2015    |
|                             |           |                     |                     | 19:11:28 UTC        |
| + 5618116c82fb9b5001400f8f  | succeeded | pytests             | st2cd.pytests_split | Fri, 09 Oct 2015    |
|                             |           |                     |                     | 19:11:40 UTC        |
|    5618116c82fb9b50075767d7 | succeeded | make_compile        | core.remote         | Fri, 09 Oct 2015    |
|                             |           |                     |                     | 19:11:40 UTC        |
|    5618116f82fb9b50075767d9 | succeeded | make_reqmnts        | core.remote         | Fri, 09 Oct 2015    |
|                             |           |                     |                     | 19:11:43 UTC        |
|    5618122582fb9b50075767db | succeeded | make_lint           | core.remote         | Fri, 09 Oct 2015    |
|                             |           |                     |                     | 19:14:45 UTC        |
|    561812b682fb9b50075767e0 | succeeded | make_tests          | core.remote         | Fri, 09 Oct 2015    |
|                             |           |                     |                     | 19:17:10 UTC        |
|   5618140d82fb9b5001400fa3  | running   | upload_coverage_rep | st2cd.publish_cover | Fri, 09 Oct 2015    |
|                             |           | ort                 | age_report          | 19:22:53 UTC        |
```
