### PR TITLE
adding RHEL6 Workroom test to CI matrix

### DIFF
--- a/rules/st2_workroom_test_el6.yaml
+++ b/rules/st2_workroom_test_el6.yaml
@@ -1,0 +1,26 @@
+---
+    name: "st2_workroom_test_el6.yaml"
+    description: "Run st2workroom_tests on each commit to st2workroom/master"
+    pack: "st2cd"
+    enabled: true
+    trigger:
+        type: "GitHubWebhook.github_event"
+    criteria:
+        trigger.body.ref:
+            pattern: "refs/heads/master"
+            type: "equals"
+        trigger.body.repository.full_name:
+            pattern: "StackStorm/st2workroom"
+            type: "equals"
+    action:
+        ref: "st2cd.st2workroom_test"
+        parameters:
+            # Would be nice to be able to use trigger.id since that is guaranteed to be unique.
+            hostname: "st2w-master-el6-{{trigger.body.head_commit.id | truncate(10, False, '')}}"
+            build: "{{system.st2_master_build_number}}"
+            version: "{{system.st2_unstable_version}}"
+            environment: "sandbox"
+            branch: "master"
+            revision: "{{trigger.body.head_commit.id}}"
+            repo: "https://github.com/StackStorm/st2workroom.git"
+            distro: "RHEL6"


### PR DESCRIPTION
This PR adds a rule to test workroom on RHEL 6 on pushes to master.
