### PR TITLE
Remove distro restriction for workroom notification

### DIFF
--- a/rules/st2cd_slack_workroom_test.yaml
+++ b/rules/st2cd_slack_workroom_test.yaml
@@ -8,9 +8,6 @@
         trigger.action_name:
             pattern: "st2cd.st2workroom_test"
             type: "equals"
-        trigger.parameters.distro:
-            pattern: "UBUNTU14"
-            type: "equals"
     action:
         ref: "slack.post_message"
         parameters:


### PR DESCRIPTION
- Now we notify for all distros.
