### PR TITLE
Fix rules

### DIFF
--- a/actions/st2workroom_test.meta.yaml
+++ b/actions/st2workroom_test.meta.yaml
@@ -57,6 +57,10 @@
     role:
       type: "string"
       default: ""
+    pkg_st2:
+      description: "Pass through property for downstream consumption."
+      type: "boolean"
+      default: false
     skip_notify:
       default:
         - delete_existing_puppet

--- a/rules/st2_pkg_prod_master_el6.yaml
+++ b/rules/st2_pkg_prod_master_el6.yaml
@@ -18,6 +18,9 @@
         trigger.parameters.distro:
             pattern: "RHEL6"
             type: "equals"
+        trigger.parameters.pkg_st2:
+            pattern: true
+            type: "equals"
     action:
         ref: "st2cd.st2_pkg_el"
         parameters:

--- a/rules/st2_pkg_prod_master_el7.yaml
+++ b/rules/st2_pkg_prod_master_el7.yaml
@@ -18,6 +18,9 @@
         trigger.parameters.distro:
             pattern: "RHEL7"
             type: "equals"
+        trigger.parameters.pkg_st2:
+            pattern: true
+            type: "equals"
     action:
         ref: "st2cd.st2_pkg_el"
         parameters:

--- a/rules/st2_pkg_prod_master_ubuntu14.yaml
+++ b/rules/st2_pkg_prod_master_ubuntu14.yaml
@@ -18,6 +18,9 @@
         trigger.parameters.distro:
             pattern: "UBUNTU14"
             type: "equals"
+        trigger.parameters.pkg_st2:
+            pattern: true
+            type: "equals"
     action:
         ref: "st2cd.st2_pkg_ubuntu14"
         parameters:

--- a/rules/st2workroom_test_master_el6.yaml
+++ b/rules/st2workroom_test_master_el6.yaml
@@ -30,6 +30,8 @@
             environment: "sandbox"
             branch: "{{trigger.parameters.branch}}"
             revision: "{{trigger.parameters.revision}}"
-            repo: "https://github.com/StackStorm/st2workroom.git"
+            repo: "{{trigger.parameters.repo}}"
             instance_type: "m3.large"
             distro: "RHEL6"
+            pkg_st2: true
+

--- a/rules/st2workroom_test_master_el7.yaml
+++ b/rules/st2workroom_test_master_el7.yaml
@@ -30,6 +30,7 @@
             environment: "sandbox"
             branch: "{{trigger.parameters.branch}}"
             revision: "{{trigger.parameters.revision}}"
-            repo: "https://github.com/StackStorm/st2workroom.git"
+            repo: "{{trigger.parameters.repo}}"
             instance_type: "m3.large"
             distro: "RHEL7"
+            pkg_st2: true

--- a/rules/st2workroom_test_master_ubuntu14.yaml
+++ b/rules/st2workroom_test_master_ubuntu14.yaml
@@ -27,5 +27,6 @@
             environment: "sandbox"
             branch: "{{trigger.parameters.branch}}"
             revision: "{{trigger.parameters.revision}}"
-            repo: "https://github.com/StackStorm/st2workroom.git"
+            repo: "{{trigger.parameters.repo}}"
             distro: "UBUNTU14"
+            pkg_st2: true


### PR DESCRIPTION
new pkg_st2 property for controlling build pipeline

Also, using the repo from the parameters. The repo value is not of much use to the `st2workroom_test` action. It is actually used during production packaging and requires to point to `st2` repo.
