### PR TITLE
concurrency policy

### DIFF
--- a/policies/pytest_concurrency.yaml
+++ b/policies/pytest_concurrency.yaml
@@ -1,7 +1,9 @@
-name: pytests.concurrency
-description: Limits the concurrent executions of pytests.
+name: pytests_split.concurrency
+description: Limits the concurrent executions of pytests_split.
 enabled: true
-resource_ref: st2cd.pytests
+resource_ref: st2cd.pytests_split
 policy_type: action.concurrency
 parameters:
     threshold: 2
+    attributes:
+        - build_server

--- a/policies/pytest_concurrency.yaml
+++ b/policies/pytest_concurrency.yaml
@@ -1,0 +1,7 @@
+name: pytests.concurrency
+description: Limits the concurrent executions of pytests.
+enabled: true
+resource_ref: st2cd.pytests
+policy_type: action.concurrency
+parameters:
+    threshold: 2


### PR DESCRIPTION
Setting concurrency to 2. We can bump it up as the build servers are increased.
