### PR TITLE
Add policy for retrying pytests_split on timeout

### DIFF
--- a/policies/retry_pytests_on_timeout.yaml
+++ b/policies/retry_pytests_on_timeout.yaml
@@ -1,0 +1,9 @@
+---
+name: pytests_split.retry_on_timeout
+description: Retry pytests_split action on timeout
+enabled: true
+resource_ref: st2cd.pytests_split
+policy_type: action.retry
+parameters:
+    retry_on: timeout
+    max_retry_count: 2


### PR DESCRIPTION
Note: We can't merge this yet - we need to upgrade build server first (and before that, we need to fix github webhook sensor).
