### PR TITLE
Modify st2_docs workflow

### DIFF
--- a/actions/st2_docs.meta.yaml
+++ b/actions/st2_docs.meta.yaml
@@ -1,10 +1,11 @@
 ---
   name: "docs"
+  pack: "st2cd"
   runner_type: "action-chain"
   description: "Build st2docs"
   enabled: true
   entry_point: "workflows/st2_docs.yaml"
-  parameters: 
+    parameters: 
     repo: 
       type: "string"
       description: "Url of the repo to clone"
@@ -14,23 +15,13 @@
       description: "The branch to build the docs from"
       default: "master"
       required: true
-    build:
-      type: "string"
-      description: "Build number"
-      required: true
     repo_target: 
       type: "string"
       default: "st2_{{branch}}"
       description: "Target directory for repo to be cloned in to."
-    revision: 
-      type: "string"
-      description: ""
-    author: 
-      type: "string"
-      description: ""
     environment:
       type: "string"
-      description: ""
+      description: "'staging' or 'production' (to push to docs.stackstorm.com)"
     docs_url:
       type: "string"
       default: "docs-staging.uswest2.stackstorm.net"

--- a/actions/workflows/st2_docs.yaml
+++ b/actions/workflows/st2_docs.yaml
@@ -1,13 +1,6 @@
 ---
   chain:
     -
-      name: "get_current_build"
-      ref: "st2cd.kvstore"
-      params:
-        key: "st2_{{branch}}_build_number"
-        action: "get"
-      on-success: "get_build_server"
-    -
       name: "get_build_server"
       ref: "linux.dig"
       params:
@@ -44,14 +37,6 @@
         cmd: "echo -e '{{version}}' | cut -d '.' -f1-2"
       publish:
         short_version: "{{short_version.stdout}}"
-      on-success: "version_hack"
-    - 
-      name: "version_hack"
-      ref: "st2cd.version_hack"
-      params: 
-        hosts: "{{build_server}}"
-        repo: "{{repodir}}"
-        build: "{{get_current_build.result}}"
       on-success: "update_url"
     -
       name: "update_url"
@@ -84,5 +69,3 @@
       params:
         hosts: "{{build_server}}"
         repo: "{{repodir}}"
-
-  default: "get_current_build"

--- a/rules/st2_docs_prod.yaml
+++ b/rules/st2_docs_prod.yaml
@@ -1,6 +1,6 @@
 ---
     name: "st2_docs_prod"
-    description: "Build st2 packages after tests succeed and push them to staging"
+    description: "Build Docs after tests succeed and push them to docs.stackstorm.com"
     enabled: true
     trigger:
         type: "core.st2.generic.actiontrigger"
@@ -22,7 +22,5 @@
         parameters:
             repo: "{{trigger.parameters.repo}}"
             branch: "{{trigger.parameters.branch}}"
-            revision: "{{trigger.parameters.revision}}"
             environment: "production"
-            build: "{{trigger.parameters.build}}"
             docs_url: "{{system.s3_bucket_docs_production}}"

--- a/rules/st2_docs_staging.yaml
+++ b/rules/st2_docs_staging.yaml
@@ -1,6 +1,6 @@
 ---
     name: "st2_docs_staging"
-    description: "Build st2 packages after tests succeed and push them to staging"
+    description: "Build Docs after tests succeed and push them to staging"
     enabled: true
     trigger:
         type: "core.st2.generic.actiontrigger"
@@ -17,6 +17,4 @@
             repo: "{{trigger.parameters.repo}}"
             branch: "{{trigger.parameters.branch}}"
             environment: "staging"
-            revision: "{{trigger.parameters.revision}}"
-            build: "{{trigger.result.tasks[1].result.result.value}}"
             docs_url: "{{system.s3_bucket_docs_staging}}"


### PR DESCRIPTION
With this, st2_docs can run 'standalone', independent of full st2 build, to make and push docs from any branch to s3.

I removed the stuff and steps that seem to be not used.

Tested by running manually on st2build002. Didn't test as part of the whole build yet.
