### PR TITLE
Fix hostname conflict

### DIFF
--- a/actions/workflows/workroom_puppet_st2_ci.yaml
+++ b/actions/workflows/workroom_puppet_st2_ci.yaml
@@ -50,7 +50,7 @@
       name: "run_workroom_tests"
       ref: "st2cd.st2workroom_test"
       params:
-        hostname: "st2w-ci-{{ revision | truncate(10, False, '') }}"
+        hostname: "st2w-ci-{{distro}}-{{ revision | truncate(10, False, '') }}"
         build: "{{latest_unstable_revision}}"
         version: "{{latest_unstable_version}}"
         environment: "sandbox"


### PR DESCRIPTION
Problem: when rules with different distors fire the workflow at the same time, VM creation fails for all but first because the DNS name is already taken.
