### PR TITLE
Add some basic checks which verify that a no default private and public key is installed for stanley

### DIFF
--- a/actions/scripts/stanley_ssh_key_checks.sh
+++ b/actions/scripts/stanley_ssh_key_checks.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 
-PRIVATE_KEY_PATH="/home/stanley/.ssh/st2_stanley_key"
+# Default file name for the stanley private key file
+DEFAULT_KEY_FILE_NAME="st2_stanley_key"
+
+PRIVATE_KEY_PATH="/home/stanley/.ssh/${DEFAULT_KEY_FILE_NAME}"
 AUTHORIZED_KEYS_PATH="/home/stanley/.ssh/authorized_keys"
 
 # 1. Verify default private key is not installed
 if [ -f ${PRIVATE_KEY_PATH} ]; then
-    echo "Private SSH key file exists for stanley user"
+    echo "Found default private ssh key (${PRIVATE_KEY_PATH}) for stanley user"
     exit 1
 fi
 
-# 2. Verify no other private key is installed
+# 2. Verify no other private keys are installed
 PRIVATE_KEY_FILES=$(find /home/stanley/.ssh/ -type f ! -name authorized_keys | wc -l)
 
 if [ ${PRIVATE_KEY_FILES} -gt 0 ]; then
@@ -18,11 +21,13 @@ if [ ${PRIVATE_KEY_FILES} -gt 0 ]; then
 fi
 
 # 3. Verify default publich key is not installed
-AUTHORIZED_KEYS_LINES=$(cat /home/stanley/.ssh/authorized_keys | grep st2_stanley_key | wc -l)
+if [ -f ${AUTHORIZED_KEYS_PATH} ]; then
+    AUTHORIZED_KEYS_LINES=$(cat ${AUTHORIZED_KEYS_PATH} | grep ${DEFAULT_KEY_FILE_NAME} | wc -l)
 
-if [ ${AUTHORIZED_KEYS_LINES} -gt 0 ]; then
-    echo "Found default stanley key in authorized_keys"
-    exit 3
+    if [ ${AUTHORIZED_KEYS_LINES} -gt 0 ]; then
+        echo "Found default stanley public key in authorized_keys (${AUTHORIZED_KEYS_PATH})"
+        exit 3
+    fi
 fi
 
 exit 0

--- a/actions/scripts/stanley_ssh_key_checks.sh
+++ b/actions/scripts/stanley_ssh_key_checks.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+PRIVATE_KEY_PATH="/home/stanley/.ssh/st2_stanley_key"
+AUTHORIZED_KEYS_PATH="/home/stanley/.ssh/authorized_keys"
+
+# 1. Verify default private key is not installed
+if [ -f ${PRIVATE_KEY_PATH} ]; then
+    echo "Private SSH key file exists for stanley user"
+    exit 1
+fi
+
+# 2. Verify no other private key is installed
+PRIVATE_KEY_FILES=$(find /home/stanley/.ssh/ -type f ! -name authorized_keys | wc -l)
+
+if [ ${PRIVATE_KEY_FILES} -gt 0 ]; then
+    echo "Found private SSH key files for stanley user"
+    exit 2
+fi
+
+# 3. Verify default publich key is not installed
+AUTHORIZED_KEYS_LINES=$(cat /home/stanley/.ssh/authorized_keys | grep st2_stanley_key | wc -l)
+
+if [ ${AUTHORIZED_KEYS_LINES} -gt 0 ]; then
+    echo "Found default stanley key in authorized_keys"
+    exit 3
+fi
+
+exit 0

--- a/actions/st2workroom_verify_default_stanley_ssh_keys_are_not_installed.yaml
+++ b/actions/st2workroom_verify_default_stanley_ssh_keys_are_not_installed.yaml
@@ -1,0 +1,8 @@
+
+----
+  name: "st2workroom_verify_default_stanley_ssh_keys_are_not_installed"
+  runner_type: "remote-shell-script"
+  description: "Script which verifies that no SSH key (private and public) is installed by default for stanley user"
+  enabled: true
+  entry_point: "scripts/stanley_ssh_key_checks.sh"
+  parameters: {}

--- a/actions/workflows/st2workroom_test.yaml
+++ b/actions/workflows/st2workroom_test.yaml
@@ -76,27 +76,13 @@
         distro: "{{distro}}"
         user: "{{st2_username}}"
         pass: "{{st2_password}}"
-      on-success: "verify_no_default_private_ssh_key_is_installed_for_stanley_1"
+      on-success: "verify_no_default_keys_are_installed_for_stanley_user"
     -
-      name: "verify_no_default_private_ssh_key_is_installed_for_stanley_1"
-      ref: "core.remote_sudo"
+      name: "verify_no_default_keys_are_installed_for_stanley_user"
+      ref: "st2cd.st2workroom_verify_default_stanley_ssh_keys_are_not_installed"
       params:
         hosts: "{{hostname}}"
-        cmd: 'test -f /home/stanley/.ssh/st2_stanley_key && (echo "Private SSH key file exists for stanley user" ; exit 1)'
-      on-success: "verify_no_default_private_ssh_key_is_installed_for_stanley_2"
-    -
-      name: "verify_no_default_private_ssh_key_is_installed_for_stanley_2"
-      ref: "core.remote_sudo"
-      params:
-        hosts: "{{hostname}}"
-        cmd: 'files=$(find /home/stanley/.ssh/ -type f ! -name authorized_keys | wc -l) ; if [ $files -gt 0 ]; then echo "Found SSH key files"; exit 1; fi'
-      on-success: "verify_no_default_authorized_key_is_installed_for_instaley"
-    -
-      name: "verify_no_default_authorized_key_is_installed_for_instaley"
-      ref: "core.remote_sudo"
-      params:
-        hosts: "{{hostname}}"
-        cmd: 'lines=$(cat /home/stanley/.ssh/authorized_keys | grep st2_stanley_key | wc -l) ; if [ $lines -gt 0 ]; then echo "Found default stanley in authorized_keys"; exit 1; fi'
+        sudo: true
       on-success: "run_tests"
     # TODO: Also add a test case for scenario where  st2::stanley::ssh_private_key, etc is provided
     -

--- a/actions/workflows/st2workroom_test.yaml
+++ b/actions/workflows/st2workroom_test.yaml
@@ -76,7 +76,29 @@
         distro: "{{distro}}"
         user: "{{st2_username}}"
         pass: "{{st2_password}}"
+      on-success: "verify_no_default_private_ssh_key_is_installed_for_stanley_1"
+    -
+      name: "verify_no_default_private_ssh_key_is_installed_for_stanley_1"
+      ref: "core.remote_sudo"
+      params:
+        hosts: "{{hostname}}"
+        cmd: 'test -f /home/stanley/.ssh/st2_stanley_key && (echo "Private SSH key file exists for stanley user" ; exit 1)'
+      on-success: "verify_no_default_private_ssh_key_is_installed_for_stanley_2"
+    -
+      name: "verify_no_default_private_ssh_key_is_installed_for_stanley_2"
+      ref: "core.remote_sudo"
+      params:
+        hosts: "{{hostname}}"
+        cmd: 'files=$(find /home/stanley/.ssh/ -type f ! -name authorized_keys | wc -l) ; if [ $files -gt 0 ]; then echo "Found SSH key files"; exit 1; fi'
+      on-success: "verify_no_default_authorized_key_is_installed_for_instaley"
+    -
+      name: "verify_no_default_authorized_key_is_installed_for_instaley"
+      ref: "core.remote_sudo"
+      params:
+        hosts: "{{hostname}}"
+        cmd: 'lines=$(cat /home/stanley/.ssh/authorized_keys | grep st2_stanley_key | wc -l) ; if [ $lines -gt 0 ]; then echo "Found default stanley in authorized_keys"; exit 1; fi'
       on-success: "run_tests"
+    # TODO: Also add a test case for scenario where  st2::stanley::ssh_private_key, etc is provided
     -
       name: "run_tests"
       ref: "st2cd.e2e_tests"


### PR DESCRIPTION
This pull request adds some basic checks which verify that a no default private key and public key is installed for stanley user after install.sh script completes.

As an additional check / improvement we should also add some tests which verify that the key is indeed installed when `st2::stanley::ssh_private_key` value is set in the answers file.
