### PR TITLE
Re-enable default SSH key checks

### DIFF
--- a/actions/workflows/st2workroom_st2enterprise_test.yaml
+++ b/actions/workflows/st2workroom_st2enterprise_test.yaml
@@ -72,8 +72,15 @@
         hosts: "{{hostname}}"
         cmd: "curl -sSL https://stackstorm.com/install.sh  | sudo sh -s -- -a /tmp/answers.yaml"
         timeout: 3600
-      on-success: "verify_rbac_is_enabled"
+      on-success: "verify_no_default_keys_are_installed_for_stanley_user"
       on-failure: "destroy_vm"
+    -
+      name: "verify_no_default_keys_are_installed_for_stanley_user"
+      ref: "st2cd.st2workroom_verify_default_stanley_ssh_keys_are_not_installed"
+      params:
+        hosts: "{{hostname}}"
+        sudo: true
+      on-success: "verify_no_default_keys_are_installed_for_stanley_user"
     -
       name: "verify_rbac_is_enabled"
       ref: "core.remote_sudo"

--- a/actions/workflows/st2workroom_st2enterprise_test.yaml
+++ b/actions/workflows/st2workroom_st2enterprise_test.yaml
@@ -58,7 +58,7 @@
         hosts: "{{hostname}}"
         cmd: "curl -sSL https://stackstorm.com/install.sh  | sudo sh -s -- -a /tmp/answers.yaml"
         timeout: 3600
-      on-success: "verify_rbac_is_enabled"
+      on-success: "verify_no_default_keys_are_installed_for_stanley_user"
       on-failure: "rerun_bootstrap_workroom_with_answers_file"
     -
       name: "rerun_bootstrap_workroom_with_answers_file"

--- a/actions/workflows/st2workroom_test.yaml
+++ b/actions/workflows/st2workroom_test.yaml
@@ -78,16 +78,15 @@
         distro: "{{distro}}"
         user: "{{st2_username}}"
         pass: "{{st2_password}}"
-      on-success: "run_tests"
-    #  on-success: "verify_no_default_keys_are_installed_for_stanley_user"
+      on-success: "verify_no_default_keys_are_installed_for_stanley_user"
     # TODO: Also add a test case for scenario where  st2::stanley::ssh_private_key, etc is provided
-    #-
-    #  name: "verify_no_default_keys_are_installed_for_stanley_user"
-    #  ref: "st2cd.st2workroom_verify_default_stanley_ssh_keys_are_not_installed"
-    #  params:
-    #    hosts: "{{hostname}}"
-    #    sudo: true
-    #  on-success: "run_tests"
+    -
+      name: "verify_no_default_keys_are_installed_for_stanley_user"
+      ref: "st2cd.st2workroom_verify_default_stanley_ssh_keys_are_not_installed"
+      params:
+        hosts: "{{hostname}}"
+        sudo: true
+      on-success: "run_tests"
     -
       name: "run_tests"
       ref: "st2cd.e2e_tests"

--- a/actions/workflows/st2workroom_test.yaml
+++ b/actions/workflows/st2workroom_test.yaml
@@ -54,7 +54,7 @@
         hosts: "{{hostname}}"
         cmd: "curl -sSL {{install_url}}  | sudo sh -s -- -a /tmp/answers.yaml"
         timeout: 3600
-      on-success: "add_ci_user"
+      on-success: "verify_no_default_keys_are_installed_for_stanley_user"
       on-failure: "rerun_bootstrap_workroom_with_answers_file"
     -
       name: "rerun_bootstrap_workroom_with_answers_file"
@@ -69,6 +69,14 @@
         hosts: "{{hostname}}"
         cmd: "curl -sSL {{install_url}}  | sudo sh -s -- -a /tmp/answers.yaml"
         timeout: 3600
+      on-success: "verify_no_default_keys_are_installed_for_stanley_user"
+    # TODO: Also add a test case for scenario where  st2::stanley::ssh_private_key, etc is provided
+    -
+      name: "verify_no_default_keys_are_installed_for_stanley_user"
+      ref: "st2cd.st2workroom_verify_default_stanley_ssh_keys_are_not_installed"
+      params:
+        hosts: "{{hostname}}"
+        sudo: true
       on-success: "add_ci_user"
     -
       name: "add_ci_user"
@@ -78,14 +86,6 @@
         distro: "{{distro}}"
         user: "{{st2_username}}"
         pass: "{{st2_password}}"
-      on-success: "verify_no_default_keys_are_installed_for_stanley_user"
-    # TODO: Also add a test case for scenario where  st2::stanley::ssh_private_key, etc is provided
-    -
-      name: "verify_no_default_keys_are_installed_for_stanley_user"
-      ref: "st2cd.st2workroom_verify_default_stanley_ssh_keys_are_not_installed"
-      params:
-        hosts: "{{hostname}}"
-        sudo: true
       on-success: "run_tests"
     -
       name: "run_tests"


### PR DESCRIPTION
This should be merged after https://github.com/StackStorm/st2workroom/pull/305 is merged into master otherwise workroom tests will fail.

(Previously I enabled it so I could more easily test those changes on build server)

TODO:
- [x] Make sure we explicitly install a new default SSH key after this check so it can be used by the tests
