### PR TITLE
Include missing /

### DIFF
--- a/actions/fetch_puppet_bootstrap.yaml
+++ b/actions/fetch_puppet_bootstrap.yaml
@@ -4,23 +4,23 @@
   description: "Download puppet bootstrap script"
   enabled: true
   entry_point: ""
-  parameters: 
-    sudo: 
+  parameters:
+    sudo:
       immutable: true
       default: true
-    cmd: 
+    cmd:
       immutable: true
-      default: "curl -XGET -o {{dir}}{{file}} -u {{token}}:x-oauth-basic https://raw.githubusercontent.com/StackStorm/st2puppet/{{branch}}/script/{{file}}"
+      default: "curl -XGET -o {{dir}}/{{file}} -u {{token}}:x-oauth-basic https://raw.githubusercontent.com/StackStorm/st2puppet/{{branch}}/script/{{file}}"
     branch:
       type: "string"
       description: "Branch of the st2puppet repo to retrive script from"
       default: "production"
-    file: 
+    file:
       type: "string"
       default: "bootstrap-puppet"
-    token: 
+    token:
       type: "string"
       default: ""
-    kwarg_op: 
+    kwarg_op:
       immutable: true
       default: "--"

--- a/actions/run_puppet_bootstrap.yaml
+++ b/actions/run_puppet_bootstrap.yaml
@@ -4,16 +4,16 @@
   description: "Run puppet bootstrap script"
   enabled: true
   entry_point: ""
-  parameters: 
-    sudo: 
+  parameters:
+    sudo:
       immutable: true
       default: true
-    cmd: 
+    cmd:
       immutable: true
-      default: "bash {{dir}}{{file}}"
+      default: "bash {{dir}}/{{file}}"
     file:
       type: "string"
       default: "bootstrap-puppet"
-    kwarg_op: 
+    kwarg_op:
       immutable: true
       default: "--"


### PR DESCRIPTION
- Missing `/` mean we end up with `/tmpbootstrap` instead of `/tmp/bootstrap`
- Whitespace was just editor doing its thing
