### PR TITLE
Update install URLs to install.stackstorm.com

### DIFF
--- a/actions/create_workroom_test_rule.py
+++ b/actions/create_workroom_test_rule.py
@@ -5,11 +5,7 @@ import json
 import requests
 import sys
 
-INSTALL_URLS = {
-    'UBUNTU14': 'https://stackstorm.com/install.sh',
-    'RHEL6': 'https://raw.githubusercontent.com/StackStorm/st2workroom/master/script/bootstrap-st2',
-    'RHEL7': 'https://raw.githubusercontent.com/StackStorm/st2workroom/master/script/bootstrap-st2'
-}
+INSTALL_URL = 'https://install.stackstorm.com/'
 
 
 def create_rule(url, rule):
@@ -51,7 +47,7 @@ def _get_st2_rules_url(base_url):
 
 def _create_distro_rule_meta(distro, branch, action_ref, version_task_index, distro_release=None):
     # last 3 chars is distro short
-    distro_short = distros[len(distros)-3:]
+    distro_short = distro[len(distro)-3:]
     rule_meta = {
         'name': 'st2_workroom_test_%s_%s' % (branch, distro.lower()),
         'pack': 'st2cd',
@@ -109,7 +105,7 @@ def _create_distro_rule_meta(distro, branch, action_ref, version_task_index, dis
     distro_type = rule_meta['action']['parameters']['distro']
     if distro_type:
         distro_type = distro_type.upper()
-        rule_meta['action']['parameters']['install_url'] = INSTALL_URLS[distro_type]
+        rule_meta['action']['parameters']['install_url'] = INSTALL_URL
 
     return rule_meta
 

--- a/actions/st2workroom_test.meta.yaml
+++ b/actions/st2workroom_test.meta.yaml
@@ -64,7 +64,7 @@
     install_url:
       description: "URL for st2 install.sh"
       type: "string"
-      default: "https://stackstorm.com/install.sh"
+      default: "https://install.stackstorm.com/"
     skip_notify:
       default:
         - delete_existing_puppet

--- a/actions/workflows/st2workroom_st2enterprise_test.yaml
+++ b/actions/workflows/st2workroom_st2enterprise_test.yaml
@@ -56,7 +56,7 @@
           DISABLE_HUBOT: "true"
           CI: "true"
         hosts: "{{hostname}}"
-        cmd: "curl -sSL https://stackstorm.com/install.sh  | sudo sh -s -- -a /tmp/answers.yaml"
+        cmd: "curl -sSL https://install.stackstorm.com/  | sudo sh -s -- -a /tmp/answers.yaml"
         timeout: 3600
       on-success: "verify_rbac_is_enabled"
       on-failure: "rerun_bootstrap_workroom_with_answers_file"
@@ -70,7 +70,7 @@
           DISABLE_HUBOT: "true"
           CI: "true"
         hosts: "{{hostname}}"
-        cmd: "curl -sSL https://stackstorm.com/install.sh  | sudo sh -s -- -a /tmp/answers.yaml"
+        cmd: "curl -sSL https://install.stackstorm.com/  | sudo sh -s -- -a /tmp/answers.yaml"
         timeout: 3600
       on-success: "verify_rbac_is_enabled"
       on-failure: "destroy_vm"

--- a/rules/st2_workroom_test_el6.yaml
+++ b/rules/st2_workroom_test_el6.yaml
@@ -24,4 +24,4 @@
             revision: "{{trigger.body.head_commit.id}}"
             repo: "https://github.com/StackStorm/st2workroom.git"
             distro: "RHEL6"
-            install_url: "https://raw.githubusercontent.com/StackStorm/st2workroom/master/script/bootstrap-st2"
+            install_url: "https://install.stackstorm.com/"

--- a/rules/st2_workroom_test_el7.yaml
+++ b/rules/st2_workroom_test_el7.yaml
@@ -24,4 +24,4 @@
             revision: "{{trigger.body.head_commit.id}}"
             repo: "https://github.com/StackStorm/st2workroom.git"
             distro: "RHEL7"
-            install_url: "https://raw.githubusercontent.com/StackStorm/st2workroom/master/script/bootstrap-st2"
+            install_url: "https://install.stackstorm.com/"

--- a/rules/st2_workroom_test_u14.yaml
+++ b/rules/st2_workroom_test_u14.yaml
@@ -24,4 +24,4 @@
             revision: "{{trigger.body.head_commit.id}}"
             repo: "https://github.com/StackStorm/st2workroom.git"
             distro: "UBUNTU14"
-            install_url: "https://stackstorm.com/install.sh"
+            install_url: "https://install.stackstorm.com/"

--- a/rules/st2workroom_test_master_el6.yaml
+++ b/rules/st2workroom_test_master_el6.yaml
@@ -34,5 +34,5 @@
             instance_type: "m3.large"
             distro: "RHEL6"
             pkg_st2: true
-            install_url: "https://raw.githubusercontent.com/StackStorm/st2workroom/master/script/bootstrap-st2"
+            install_url: "https://install.stackstorm.com"
 

--- a/rules/st2workroom_test_master_el7.yaml
+++ b/rules/st2workroom_test_master_el7.yaml
@@ -34,5 +34,5 @@
             instance_type: "m3.large"
             distro: "RHEL7"
             pkg_st2: true
-            install_url: "https://raw.githubusercontent.com/StackStorm/st2workroom/master/script/bootstrap-st2"
+            install_url: "https://install.stackstorm.com/"
 


### PR DESCRIPTION
See https://stackstorm.atlassian.net/browse/STORM-1946 for the reasons. We did install.stackstorm.com so we can support cipherlists supported by RHEL6. So let's use the latest and greatest links. 
