### PR TITLE
Add policies for retrying st2workroom_* test workflows on failure (up to 1 time)

### DIFF
--- a/policies/retry_st2workroom_st2enterprise_test_on_failure.yaml
+++ b/policies/retry_st2workroom_st2enterprise_test_on_failure.yaml
@@ -1,0 +1,11 @@
+---
+name: st2workroom_st2enterprise_test.retry_on_failure
+# Note: We retry this run on failure to try to avoid false positives
+# which are caused by intermediate networking issues and similar.
+description: Retry "st2workroom_st2enterprise_test" tests on failure for up to 1 times.
+enabled: true
+resource_ref: st2cd.st2workroom_st2enterprise_test
+policy_type: action.retry
+parameters:
+    retry_on: failure
+    max_retry_count: 1

--- a/policies/retry_st2workroom_st2enterprise_test_on_failure.yaml
+++ b/policies/retry_st2workroom_st2enterprise_test_on_failure.yaml
@@ -8,4 +8,4 @@ resource_ref: st2cd.st2workroom_st2enterprise_test
 policy_type: action.retry
 parameters:
     retry_on: failure
-    max_retry_count: 1
+    max_retry_count: 2

--- a/policies/retry_st2workroom_st2installer_st2enterprise_test_on_failure.yaml
+++ b/policies/retry_st2workroom_st2installer_st2enterprise_test_on_failure.yaml
@@ -8,4 +8,4 @@ resource_ref: st2cd.st2workroom_st2installer_st2enterprise_test
 policy_type: action.retry
 parameters:
     retry_on: failure
-    max_retry_count: 1
+    max_retry_count: 2

--- a/policies/retry_st2workroom_st2installer_st2enterprise_test_on_failure.yaml
+++ b/policies/retry_st2workroom_st2installer_st2enterprise_test_on_failure.yaml
@@ -1,0 +1,11 @@
+---
+name: st2workroom_st2installer_st2enterprise_test.retry_on_failure
+# Note: We retry this run on failure to try to avoid false positives
+# which are caused by intermediate networking issues and similar.
+description: Retry "st2workroom_st2installer_st2enterprise_test" tests on failure for up to 1 times.
+enabled: true
+resource_ref: st2cd.st2workroom_st2installer_st2enterprise_test
+policy_type: action.retry
+parameters:
+    retry_on: failure
+    max_retry_count: 1

--- a/policies/retry_st2workroom_test_on_failure.yaml
+++ b/policies/retry_st2workroom_test_on_failure.yaml
@@ -1,0 +1,11 @@
+---
+name: st2workroom_test.retry_on_failure
+# Note: We retry this run on failure to try to avoid false positives
+# which are caused by intermediate networking issues and similar.
+description: Retry "st2workroom_test" tests on failure for up to 1 times.
+enabled: true
+resource_ref: st2cd.st2workroom_test
+policy_type: action.retry
+parameters:
+    retry_on: failure
+    max_retry_count: 1

--- a/policies/retry_st2workroom_test_on_failure.yaml
+++ b/policies/retry_st2workroom_test_on_failure.yaml
@@ -8,4 +8,4 @@ resource_ref: st2cd.st2workroom_test
 policy_type: action.retry
 parameters:
     retry_on: failure
-    max_retry_count: 1
+    max_retry_count: 2


### PR DESCRIPTION
This should hopefully reduce the burden and stress of false positives (and related time consuming work of checking things out and re-running stuff) and help mitigate false positives related to networking and other intermediate / temporary issues (timeout when pulling docker images, timeout when talking to github, etc.).
