### PR TITLE
remove update_mistral_puppet

### DIFF
--- a/actions/workflows/st2_finalize_release.yaml
+++ b/actions/workflows/st2_finalize_release.yaml
@@ -50,13 +50,6 @@
       ref: "st2cd.mistral_tag_release"
       params:
         version: "{{tagged_version}}"
-      on-success: "update_mistral_puppet"
-      on-failure: "clean_repo_failure"
-    -
-      name: "update_mistral_puppet"
-      ref: "st2cd.mistral_update_deploy_version"
-      params:
-        version: "{{tagged_version}}"
       on-success: "get_next_version"
       on-failure: "clean_repo_failure"
     -


### PR DESCRIPTION
- should not update puppet anyway since it is more or less manually done to
  control st2 release upstream
- Also, the associated workflow does not really run anyway.

```
{
  "traceback": "  File \"/usr/lib/python2.7/dist-packages/st2actions/container/base.py\", line 116, in _do_run\n    (status, result, context) = runner.run(action_params)\n  File \"/usr/local/lib/python2.7/dist-packages/retrying.py\", line 49, in wrapped_f\n    return Retrying(*dargs, **dkw).call(f, *args, **kw)\n  File \"/usr/local/lib/python2.7/dist-packages/retrying.py\", line 206, in call\n    return attempt.get(self._wrap_exception)\n  File \"/usr/local/lib/python2.7/dist-packages/retrying.py\", line 247, in get\n    six.reraise(self.value[0], self.value[1], self.value[2])\n  File \"/usr/local/lib/python2.7/dist-packages/retrying.py\", line 200, in call\n    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)\n  File \"/usr/lib/python2.7/dist-packages/st2actions/runners/mistral/v2.py\", line 219, in run\n    **options)\n  File \"/usr/local/lib/python2.7/dist-packages/mistralclient/api/v2/executions.py\", line 47, in create\n    return self._create('/executions', data)\n  File \"/usr/local/lib/python2.7/dist-packages/mistralclient/api/base.py\", line 95, in _create\n    self._raise_api_exception(resp)\n  File \"/usr/local/lib/python2.7/dist-packages/mistralclient/api/base.py\", line 142, in _raise_api_exception\n    error_message=error_data)\n",
  "error": "Workflow not found [workflow_name=st2cd.mistral_update_deploy.main]"
}
```
