### PR TITLE
Pass "verbose: false" parameter to linux.rm action

### DIFF
--- a/actions/workflows/st2workroom_st2enterprise_test.yaml
+++ b/actions/workflows/st2workroom_st2enterprise_test.yaml
@@ -33,6 +33,7 @@
         target: "{{root_dir}}"
         force: true
         recursive: true
+        verbose: false
         sudo: true
       on-success: "write_answers_file"
     -

--- a/actions/workflows/st2workroom_st2installer_st2enterprise_test.yaml
+++ b/actions/workflows/st2workroom_st2installer_st2enterprise_test.yaml
@@ -32,6 +32,7 @@
         target: "{{root_dir}}"
         force: true
         recursive: true
+        verbose: false
         sudo: true
       on-success: "write_answers_file"
     -

--- a/actions/workflows/st2workroom_test.yaml
+++ b/actions/workflows/st2workroom_test.yaml
@@ -32,6 +32,7 @@
         target: "{{root_dir}}"
         force: true
         recursive: true
+        verbose: false
         sudo: true
       on-success: "write_answers_file"
     -

--- a/actions/workflows/st2workroom_upgrade_test.yaml
+++ b/actions/workflows/st2workroom_upgrade_test.yaml
@@ -26,6 +26,7 @@
         target: "{{root_dir}}"
         force: true
         recursive: true
+        verbose: false
         sudo: true
       on-success: "write_initial_answers_file"
     -


### PR DESCRIPTION
This should hopefully fix (work around) unicode related bug described here - https://github.com/StackStorm/st2/pull/2521

This bug has been causing a lot of annoying workroom failures recently.
