### PR TITLE
Fix st2_docs to run manually and deploy to staging

### DIFF
--- a/actions/st2_docs.meta.yaml
+++ b/actions/st2_docs.meta.yaml
@@ -1,13 +1,14 @@
 ---
   name: "st2_docs"
+  pack: "st2cd"
   runner_type: "action-chain"
-  description: "Build st2docs"
+  description: "Build st2docs and deploy to s3 bucket"
   enabled: true
   entry_point: "workflows/st2_docs.yaml"
   parameters:
     repo:
       type: "string"
-      description: "Url of the repo to clone"
+      description: "Url of the docs repo to clone"
       default: "https://github.com/StackStorm/st2docs.git"
     branch:
       type: "string"
@@ -17,16 +18,16 @@
     repo_target:
       type: "string"
       default: "st2_{{branch}}"
-      description: "Target directory for repo to be cloned in to."
+      description: "Target directory on server for repo to be cloned in to."
     revision:
       type: "string"
-      description: ""
+      description: "git revision SHA"
     author:
       type: "string"
-      description: ""
+      description: "git author"
     environment:
       type: "string"
-      description: ""
+      description: "'production' to deploy to docs.stackstorm.com, or 'staging'"
     docs_url:
       type: "string"
       default: "docs-staging.uswest2.stackstorm.net"

--- a/actions/workflows/st2_docs.yaml
+++ b/actions/workflows/st2_docs.yaml
@@ -1,13 +1,6 @@
 ---
   chain:
     -
-      name: "get_current_build"
-      ref: "st2cd.kvstore"
-      params:
-        key: "st2_{{branch}}_build_number"
-        action: "get"
-      on-success: "get_build_server"
-    -
       name: "get_build_server"
       ref: "linux.dig"
       params:
@@ -68,5 +61,3 @@
       params:
         hosts: "{{build_server}}"
         repo: "{{repodir}}"
-
-  default: "get_current_build"

--- a/rules/st2cd_slack_docs.yaml
+++ b/rules/st2cd_slack_docs.yaml
@@ -1,15 +1,33 @@
 ---
-    name: "st2cd_slack_docs"
+    name: "slack_docs"
+    pack: "st2cd"
     description: "Post results of st2cd workflows to slack"
     enabled: true
     trigger:
         type: "core.st2.generic.actiontrigger"
     criteria:
         trigger.action_name:
-            pattern: "st2cd.docs"
+            pattern: "st2cd.st2_docs"
             type: "equals"
     action:
         ref: "slack.post_message"
         parameters:
             channel: "{% if trigger.status == 'succeeded' %}#thunderdome{% else %}#stackstorm{% endif %}"
-            message: "{% if trigger.status != 'succeeded' %}channel\n{% endif %}```[{{trigger.action_name}} - {{trigger.parameters.environment}}: {{trigger.status.upper()}}]\n   BRANCH: {{trigger.parameters.branch}}```"
+            message: >
+                {% if trigger.status != 'succeeded' %}@channel:{% endif %}
+                ```
+                [{{trigger.action_name}} {{trigger.status.upper()}}]
+                {% if trigger.parameters.environment is defined %}
+                    environment: {{ trigger.parameters.environment }}
+                {% endif %}
+                {% if trigger.parameters.author  is defined %}
+                    author: {{ trigger.parameters.author }}
+                {% endif %}
+                {% if trigger.parameters.revision  is defined %}
+                    revision: {{ trigger.parameters.revision }}
+                {% endif %}
+                BRANCH: {{trigger.parameters.branch}}
+                ````
+                http://st2build002:8080/#/history/{{trigger.execution_id}}/general
+
+


### PR DESCRIPTION
By (finally!) removing unused dependency to current_build.

Now I can run this manually, pick any branch /commit/ PR, and deploy to staging for convenient review.
- [x] udpate st2build002 manually once this merges (currently tested with a ln -s from /home/dzimine/st2cd)
