### PR TITLE
Workflow for package promotion from staging to prod

### DIFF
--- a/actions/promote_package.yaml
+++ b/actions/promote_package.yaml
@@ -19,13 +19,17 @@ parameters:
     required: true
   os:
     description: OS to promote (will promote all if not specified)
-    required: false
+    required: true
+    default: all
     enum:
     - wheezy
     - jessie
     - trusty
     - el6
     - el7
+    - deb
+    - rpm
+    - all
   repo:
     description: "Repo to upload to: stable/unstable, community/enterprise"
     required: true

--- a/actions/promote_package.yaml
+++ b/actions/promote_package.yaml
@@ -1,0 +1,36 @@
+---
+name: promote_package
+runner_type: mistral-v2
+description: Promote a package to production from staging.
+enabled: true
+entry_point: workflows/promote_package.yaml
+parameters:
+  package:
+    type: string
+    description: Package to promote
+    required: true
+  version:
+    type: string
+    description: Version to promote
+    required: true
+  revision:
+    type: string
+    description: Revision to promote
+    required: true
+  os:
+    description: OS to promote (will promote all if not specified)
+    required: false
+    enum:
+    - wheezy
+    - jessie
+    - trusty
+    - el6
+    - el7
+  repo:
+    description: "Repo to upload to: stable/unstable, community/enterprise"
+    required: true
+    enum:
+    - stable
+    - unstable
+    - enterprise
+    - enterprise-unstable

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -21,72 +21,53 @@ st2cd.promote_package:
         input:
           cmd: "mkdir -p /tmp/st2-up/{ubuntu/trusty,debian/wheezy,debian/jessie,el/6,el/7}"
         publish:
-          el6_path:    el/6
-          el7_path:    el/7
-          rpm: <% $.package %>_<% $.version %>-<% $.revision %>.x86_64.rpm
-          deb: <% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb
-          source: <% $.repo = 'enterprise' and 'enterprise-staging' or $.repo = 'enterprise-unstable' and 'enterprise-staging-unstable' or $.repo = 'stable' and 'staging-stable' or $.repo = 'unstable' and 'staging-unstable' %>
+          rpm: "<% $.package %>_<% $.version %>-<% $.revision %>.x86_64.rpm"
+          deb: "<% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb"
+          source: "<% $.repo = 'enterprise' and 'enterprise-staging' or $.repo = 'enterprise-unstable' and 'enterprise-staging-unstable' or $.repo = 'stable' and 'staging-stable' or $.repo = 'unstable' and 'staging-unstable' %>"
+          token: "772c93363a047c25a0d113fccc0c0963cfa44a45453ba7e9"
         on-success:
           - download_trusty: "<% $.os in list(None, 'trusty') %>"
           - download_wheezy: "<% $.os in list(None, 'wheezy') %>"
           - download_jessie: "<% $.os in list(None, 'jessie') %>"
-          - download_el6: "<% $.os in list(None, 'el6') %>"
-          - download_el7: "<% $.os in list(None, 'el7') %>"
 
       download_trusty:
         action: core.local
         input:
-          cmd: "wget -p /tmp/st2-up/ubuntu/trusty/ https://packagecloud.io/StackStorm/<% $.source %>/ubuntu/pool/trusty/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
+          cmd: "wget -O /tmp/st2-up/ubuntu/trusty/<% $.deb %> https://packagecloud.io/StackStorm/<% $.source %>/ubuntu/pool/trusty/main/<% $.package.substring(0,1) %>/<% $.package %>/<% $.deb %>"
         on-success: upload_trusty
+        on-error: cleanup
       upload_trusty:
         action: core.local
         input:
-          cmd: "package_cloud push StackStorm/<% $.repo %>/ubuntu/trusty /tmp/st2-up/ubuntu/trusty/<% $.deb %>"
+          cmd: "LANG=en_US.utf8 PACKAGECLOUD_TOKEN=<% $.token %> package_cloud push StackStorm/<% $.repo %>/ubuntu/trusty /tmp/st2-up/ubuntu/trusty/<% $.deb %>"
         on-success: cleanup
+        on-error: cleanup
 
       download_wheezy:
         action: core.local
         input:
-          cmd: "wget -p /tmp/st2-up/debian/wheezy/ https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/wheezy/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
+          cmd: "wget -O /tmp/st2-up/debian/wheezy/<% $.deb %> https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/wheezy/main/<% $.package.substring(0,1) %>/<% $.package %>/<% $.deb %>"
         on-success: upload_wheezy
+        on-error: cleanup
       upload_wheezy:
         action: core.local
         input:
-          cmd: "package_cloud push StackStorm/<% $.repo %>/debian/wheezy /tmp/st2-up/debian/wheezy/<% $.deb %>"
+          cmd: "LANG=en_US.utf8 PACKAGECLOUD_TOKEN=<% $.token %> package_cloud push StackStorm/<% $.repo %>/debian/wheezy /tmp/st2-up/debian/wheezy/<% $.deb %>"
         on-success: cleanup
+        on-error: cleanup
 
       download_jessie:
         action: core.local
         input:
-          cmd: "wget -p /tmp/st2-up/debian/jessie/ https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/jessie/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
+          cmd: "wget -O /tmp/st2-up/debian/jessie/<% $.deb %> https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/jessie/main/<% $.package.substring(0,1) %>/<% $.package %>/<% $.deb %>"
         on-success: upload_jessie
+        on-error: cleanup
       upload_jessie:
         action: core.local
         input:
-          cmd: "package_cloud push StackStorm/<% $.repo %>/debian/jessie /tmp/st2-up/debian/jessie/<% $.deb %>"
+          cmd: "LANG=en_US.utf8 PACKAGECLOUD_TOKEN=<% $.token %> package_cloud push StackStorm/<% $.repo %>/debian/jessie /tmp/st2-up/debian/jessie/<% $.deb %>"
         on-success: cleanup
-
-      download_el6:
-        action: core.local
-        input:
-          cmd: "wget -p /tmp/st2-up/el/6 https://packagecloud.io/StackStorm/<% $.source %>/el/6/<% $.package %>/<% $.rpm %>"
-        on-success: upload_el6
-      upload_el6:
-        action: core.local
-        input:
-          cmd: "package_cloud push StackStorm/<% $.repo %>/el/6 /tmp/st2-up/el/6/<% $.rpm %>"
-        on-success: cleanup
-
-      download_el7:
-        action: core.local
-        input:
-          cmd: "wget -p /tmp/st2-up/el/7 https://packagecloud.io/StackStorm/<% $.source %>/el/7/<% $.package %>/<% $.rpm %>"
-        on-success: upload_el6
-      upload_el7:
-        action: core.local
-        input:
-          cmd: "package_cloud push StackStorm/<% $.repo %>/el/7 /tmp/st2-up/el/7/<% $.rpm %>"
-        on-success: cleanup
+        on-error: cleanup
 
       cleanup:
         join: all

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -1,0 +1,98 @@
+version: '2.0'
+name: st2cd.promote_package
+description: Promote a package to production.
+
+workflows:
+
+    main:
+        type: direct
+
+        input:
+            - package
+            - version
+            - revision
+            - os
+            - repo
+
+        tasks:
+
+            init:
+                action: core.local
+                input:
+                    cmd: "mkdir -p /tmp/st2-up/{ubuntu/trusty,debian/wheezy,debian/jessie,el/6,el/7}"
+                publish:
+                    - trusty_path: ubuntu/trusty
+                    - wheezy_path: debian/wheezy
+                    - jessie_path: debian/jessie
+                    - el6_path:    el/6
+                    - el7_path:    el/7
+                    - rpm: <% $.package %>_<% $.version %>-<% $.revision %>.x86_64.rpm
+                    - deb: <% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb
+                    - source: <% $.repo = 'enterprise' && 'enterprise-staging' || $.repo = 'enterprise-unstable' && 'enterprise-staging-unstable' || $.repo = 'stable' && 'staging-stable' || $.repo = 'unstable' && 'staging-unstable' %>
+                on-success:
+                    - download_trusty: <% $.os = "trusty" or not $.os %>
+                    - download_wheezy: <% $.os = "wheezy" or not $.os %>
+                    - download_jessie: <% $.os = "jessie" or not $.os %>
+                    - download_el6: <% $.os = "el6" or not $.os %>
+                    - download_el7: <% $.os = "el7" or not $.os %>
+
+            download_trusty:
+                action: core.local
+                input:
+                    cmd: "wget -p /tmp/st2-up/<% $.trusty_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.trusty_path %>/<% $.deb %>"
+                on-success: upload_trusty
+            upload_trusty:
+                action: core.local
+                input:
+                    cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.trusty_path %> /tmp/st2-up/<% $.trusty_path %>/<% $.deb %>"
+                on-success: cleanup
+
+            download_wheezy:
+                action: core.local
+                input:
+                    cmd: "wget -p /tmp/st2-up/<% $.wheezy_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.wheezy_path %>/<% $.deb %>"
+                on-success: upload_wheezy
+            upload_wheezy:
+                action: core.local
+                input:
+                    cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.wheezy_path %> /tmp/st2-up/<% $.wheezy_path %>/<% $.deb %>"
+                on-success: cleanup
+
+            download_jessie:
+                action: core.local
+                input:
+                    cmd: "wget -p /tmp/st2-up/<% $.jessie_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.jessie_path %>/<% $.deb %>"
+                on-success: upload_jessie
+            upload_jessie:
+                action: core.local
+                input:
+                    cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.jessie_path %> /tmp/st2-up/<% $.jessie_path %>/<% $.deb %>"
+                on-success: cleanup
+
+            download_el6:
+                action: core.local
+                input:
+                    cmd: "wget -p /tmp/st2-up/<% $.el6_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.el6_path %>/<% $.rpm %>"
+                on-success: upload_el6
+            upload_el6:
+                action: core.local
+                input:
+                    cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.el6_path %> /tmp/st2-up/<% $.el6_path %>/<% $.rpm %>"
+                on-success: cleanup
+
+            download_el7:
+                action: core.local
+                input:
+                    cmd: "wget -p /tmp/st2-up/<% $.el7_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.el7_path %>/<% $.rpm %>"
+                on-success: upload_el7
+            upload_el7:
+                action: core.local
+                input:
+                    cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.el7_path %> /tmp/st2-up/<% $.el7_path %>/<% $.rpm %>"
+                on-success: cleanup
+
+            cleanup:
+                join: all
+                action: core.local
+                input:
+                    cmd: "rm -rf /tmp/st2-up"

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -31,42 +31,42 @@ st2cd.promote_package:
         input:
           cmd: "wget -O /tmp/st2-up/ubuntu/trusty/<% $.deb %> https://packagecloud.io/StackStorm/<% $.source %>/ubuntu/pool/trusty/main/<% $.package.substring(0,1) %>/<% $.package %>/<% $.deb %>"
         on-success: upload_trusty
-        on-error: cleanup
+#        on-error: cleanup
       upload_trusty:
         action: core.local
         input:
           cmd: "LANG=en_US.utf8 PACKAGECLOUD_TOKEN=<% $.token %> package_cloud push StackStorm/<% $.repo %>/ubuntu/trusty /tmp/st2-up/ubuntu/trusty/<% $.deb %>"
-        on-success: cleanup
-        on-error: cleanup
+#        on-success: cleanup
+#        on-error: cleanup
 
       download_wheezy:
         action: core.local
         input:
           cmd: "wget -O /tmp/st2-up/debian/wheezy/<% $.deb %> https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/wheezy/main/<% $.package.substring(0,1) %>/<% $.package %>/<% $.deb %>"
         on-success: upload_wheezy
-        on-error: cleanup
+#        on-error: cleanup
       upload_wheezy:
         action: core.local
         input:
           cmd: "LANG=en_US.utf8 PACKAGECLOUD_TOKEN=<% $.token %> package_cloud push StackStorm/<% $.repo %>/debian/wheezy /tmp/st2-up/debian/wheezy/<% $.deb %>"
-        on-success: cleanup
-        on-error: cleanup
+#        on-success: cleanup
+#        on-error: cleanup
 
       download_jessie:
         action: core.local
         input:
           cmd: "wget -O /tmp/st2-up/debian/jessie/<% $.deb %> https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/jessie/main/<% $.package.substring(0,1) %>/<% $.package %>/<% $.deb %>"
         on-success: upload_jessie
-        on-error: cleanup
+#        on-error: cleanup
       upload_jessie:
         action: core.local
         input:
           cmd: "LANG=en_US.utf8 PACKAGECLOUD_TOKEN=<% $.token %> package_cloud push StackStorm/<% $.repo %>/debian/jessie /tmp/st2-up/debian/jessie/<% $.deb %>"
-        on-success: cleanup
-        on-error: cleanup
+#        on-success: cleanup
+#        on-error: cleanup
 
-      cleanup:
-        join: all
-        action: core.local
-        input:
-          cmd: "rm -rf /tmp/st2-up"
+#      cleanup:
+#        join: all
+#        action: core.local
+#        input:
+#          cmd: "rm -rf /tmp/st2-up"

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -1,3 +1,4 @@
+---
 version: '2.0'
 
 st2cd.promote_package:
@@ -16,20 +17,20 @@ st2cd.promote_package:
             input:
                 cmd: "mkdir -p /tmp/st2-up/{ubuntu/trusty,debian/wheezy,debian/jessie,el/6,el/7}"
             publish:
-                - trusty_path: ubuntu/trusty
-                - wheezy_path: debian/wheezy
-                - jessie_path: debian/jessie
-                - el6_path:    el/6
-                - el7_path:    el/7
-                - rpm: <% $.package %>_<% $.version %>-<% $.revision %>.x86_64.rpm
-                - deb: <% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb
-                - source: <% $.repo = 'enterprise' && 'enterprise-staging' || $.repo = 'enterprise-unstable' && 'enterprise-staging-unstable' || $.repo = 'stable' && 'staging-stable' || $.repo = 'unstable' && 'staging-unstable' %>
+                trusty_path: ubuntu/trusty
+                wheezy_path: debian/wheezy
+                jessie_path: debian/jessie
+                el6_path:    el/6
+                el7_path:    el/7
+                rpm: <% $.package %>_<% $.version %>-<% $.revision %>.x86_64.rpm
+                deb: <% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb
+                source: <% $.repo = 'enterprise' and 'enterprise-staging' or $.repo = 'enterprise-unstable' and 'enterprise-staging-unstable' or $.repo = 'stable' and 'staging-stable' or $.repo = 'unstable' and 'staging-unstable' %>
             on-success:
-                - download_trusty: <% $.os = "trusty" or not $.os %>
-                - download_wheezy: <% $.os = "wheezy" or not $.os %>
-                - download_jessie: <% $.os = "jessie" or not $.os %>
-                - download_el6: <% $.os = "el6" or not $.os %>
-                - download_el7: <% $.os = "el7" or not $.os %>
+                - download_trusty: "<% $.os in list(None, 'trusty') %>"
+                - download_wheezy: "<% $.os in list(None, 'wheezy') %>"
+                - download_jessie: "<% $.os in list(None, 'jessie') %>"
+                - download_el6: "<% $.os in list(None, 'el6') %>"
+                - download_el7: "<% $.os in list(None, 'el7') %>"
 
         download_trusty:
             action: core.local

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -1,98 +1,93 @@
 version: '2.0'
-name: st2cd.promote_package
-description: Promote a package to production.
 
-workflows:
+st2cd.promote_package:
+    description: Promote a package to production.
+    type: direct
+    input:
+        - package
+        - version
+        - revision
+        - os
+        - repo
+    tasks:
 
-    main:
-        type: direct
+        init:
+            action: core.local
+            input:
+                cmd: "mkdir -p /tmp/st2-up/{ubuntu/trusty,debian/wheezy,debian/jessie,el/6,el/7}"
+            publish:
+                - trusty_path: ubuntu/trusty
+                - wheezy_path: debian/wheezy
+                - jessie_path: debian/jessie
+                - el6_path:    el/6
+                - el7_path:    el/7
+                - rpm: <% $.package %>_<% $.version %>-<% $.revision %>.x86_64.rpm
+                - deb: <% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb
+                - source: <% $.repo = 'enterprise' && 'enterprise-staging' || $.repo = 'enterprise-unstable' && 'enterprise-staging-unstable' || $.repo = 'stable' && 'staging-stable' || $.repo = 'unstable' && 'staging-unstable' %>
+            on-success:
+                - download_trusty: <% $.os = "trusty" or not $.os %>
+                - download_wheezy: <% $.os = "wheezy" or not $.os %>
+                - download_jessie: <% $.os = "jessie" or not $.os %>
+                - download_el6: <% $.os = "el6" or not $.os %>
+                - download_el7: <% $.os = "el7" or not $.os %>
 
-        input:
-            - package
-            - version
-            - revision
-            - os
-            - repo
+        download_trusty:
+            action: core.local
+            input:
+                cmd: "wget -p /tmp/st2-up/<% $.trusty_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.trusty_path %>/<% $.deb %>"
+            on-success: upload_trusty
+        upload_trusty:
+            action: core.local
+            input:
+                cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.trusty_path %> /tmp/st2-up/<% $.trusty_path %>/<% $.deb %>"
+            on-success: cleanup
 
-        tasks:
+        download_wheezy:
+            action: core.local
+            input:
+                cmd: "wget -p /tmp/st2-up/<% $.wheezy_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.wheezy_path %>/<% $.deb %>"
+            on-success: upload_wheezy
+        upload_wheezy:
+            action: core.local
+            input:
+                cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.wheezy_path %> /tmp/st2-up/<% $.wheezy_path %>/<% $.deb %>"
+            on-success: cleanup
 
-            init:
-                action: core.local
-                input:
-                    cmd: "mkdir -p /tmp/st2-up/{ubuntu/trusty,debian/wheezy,debian/jessie,el/6,el/7}"
-                publish:
-                    - trusty_path: ubuntu/trusty
-                    - wheezy_path: debian/wheezy
-                    - jessie_path: debian/jessie
-                    - el6_path:    el/6
-                    - el7_path:    el/7
-                    - rpm: <% $.package %>_<% $.version %>-<% $.revision %>.x86_64.rpm
-                    - deb: <% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb
-                    - source: <% $.repo = 'enterprise' && 'enterprise-staging' || $.repo = 'enterprise-unstable' && 'enterprise-staging-unstable' || $.repo = 'stable' && 'staging-stable' || $.repo = 'unstable' && 'staging-unstable' %>
-                on-success:
-                    - download_trusty: <% $.os = "trusty" or not $.os %>
-                    - download_wheezy: <% $.os = "wheezy" or not $.os %>
-                    - download_jessie: <% $.os = "jessie" or not $.os %>
-                    - download_el6: <% $.os = "el6" or not $.os %>
-                    - download_el7: <% $.os = "el7" or not $.os %>
+        download_jessie:
+            action: core.local
+            input:
+                cmd: "wget -p /tmp/st2-up/<% $.jessie_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.jessie_path %>/<% $.deb %>"
+            on-success: upload_jessie
+        upload_jessie:
+            action: core.local
+            input:
+                cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.jessie_path %> /tmp/st2-up/<% $.jessie_path %>/<% $.deb %>"
+            on-success: cleanup
 
-            download_trusty:
-                action: core.local
-                input:
-                    cmd: "wget -p /tmp/st2-up/<% $.trusty_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.trusty_path %>/<% $.deb %>"
-                on-success: upload_trusty
-            upload_trusty:
-                action: core.local
-                input:
-                    cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.trusty_path %> /tmp/st2-up/<% $.trusty_path %>/<% $.deb %>"
-                on-success: cleanup
+        download_el6:
+            action: core.local
+            input:
+                cmd: "wget -p /tmp/st2-up/<% $.el6_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.el6_path %>/<% $.rpm %>"
+            on-success: upload_el6
+        upload_el6:
+            action: core.local
+            input:
+                cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.el6_path %> /tmp/st2-up/<% $.el6_path %>/<% $.rpm %>"
+            on-success: cleanup
 
-            download_wheezy:
-                action: core.local
-                input:
-                    cmd: "wget -p /tmp/st2-up/<% $.wheezy_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.wheezy_path %>/<% $.deb %>"
-                on-success: upload_wheezy
-            upload_wheezy:
-                action: core.local
-                input:
-                    cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.wheezy_path %> /tmp/st2-up/<% $.wheezy_path %>/<% $.deb %>"
-                on-success: cleanup
+        download_el7:
+            action: core.local
+            input:
+                cmd: "wget -p /tmp/st2-up/<% $.el7_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.el7_path %>/<% $.rpm %>"
+            on-success: upload_el7
+        upload_el7:
+            action: core.local
+            input:
+                cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.el7_path %> /tmp/st2-up/<% $.el7_path %>/<% $.rpm %>"
+            on-success: cleanup
 
-            download_jessie:
-                action: core.local
-                input:
-                    cmd: "wget -p /tmp/st2-up/<% $.jessie_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.jessie_path %>/<% $.deb %>"
-                on-success: upload_jessie
-            upload_jessie:
-                action: core.local
-                input:
-                    cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.jessie_path %> /tmp/st2-up/<% $.jessie_path %>/<% $.deb %>"
-                on-success: cleanup
-
-            download_el6:
-                action: core.local
-                input:
-                    cmd: "wget -p /tmp/st2-up/<% $.el6_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.el6_path %>/<% $.rpm %>"
-                on-success: upload_el6
-            upload_el6:
-                action: core.local
-                input:
-                    cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.el6_path %> /tmp/st2-up/<% $.el6_path %>/<% $.rpm %>"
-                on-success: cleanup
-
-            download_el7:
-                action: core.local
-                input:
-                    cmd: "wget -p /tmp/st2-up/<% $.el7_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.el7_path %>/<% $.rpm %>"
-                on-success: upload_el7
-            upload_el7:
-                action: core.local
-                input:
-                    cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.el7_path %> /tmp/st2-up/<% $.el7_path %>/<% $.rpm %>"
-                on-success: cleanup
-
-            cleanup:
-                join: all
-                action: core.local
-                input:
-                    cmd: "rm -rf /tmp/st2-up"
+        cleanup:
+            join: all
+            action: core.local
+            input:
+                cmd: "rm -rf /tmp/st2-up"

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -1,7 +1,3 @@
-# TODO: handle 404
-# TODO: handle uninitialized package_cloud
-# TODO: handle success on every os (messages)
-
 ---
 version: '2.0'
 
@@ -21,72 +17,53 @@ st2cd.promote_package:
         input:
           cmd: "mkdir -p /tmp/st2-up/{ubuntu/trusty,debian/wheezy,debian/jessie,el/6,el/7}"
         publish:
-          el6_path:    el/6
-          el7_path:    el/7
-          rpm: <% $.package %>_<% $.version %>-<% $.revision %>.x86_64.rpm
-          deb: <% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb
-          source: <% $.repo = 'enterprise' and 'enterprise-staging' or $.repo = 'enterprise-unstable' and 'enterprise-staging-unstable' or $.repo = 'stable' and 'staging-stable' or $.repo = 'unstable' and 'staging-unstable' %>
+          rpm: "<% $.package %>_<% $.version %>-<% $.revision %>.x86_64.rpm"
+          deb: "<% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb"
+          source: "<% $.repo = 'enterprise' and 'enterprise-staging' or $.repo = 'enterprise-unstable' and 'enterprise-staging-unstable' or $.repo = 'stable' and 'staging-stable' or $.repo = 'unstable' and 'staging-unstable' %>"
+          token: ""
         on-success:
-          - download_trusty: "<% $.os in list(None, 'trusty') %>"
-          - download_wheezy: "<% $.os in list(None, 'wheezy') %>"
-          - download_jessie: "<% $.os in list(None, 'jessie') %>"
-          - download_el6: "<% $.os in list(None, 'el6') %>"
-          - download_el7: "<% $.os in list(None, 'el7') %>"
+          - download_trusty: "<% $.os in list('all', 'deb', 'trusty') %>"
+          - download_wheezy: "<% $.os in list('all', 'deb', 'wheezy') %>"
+          - download_jessie: "<% $.os in list('all', 'deb', 'jessie') %>"
 
       download_trusty:
         action: core.local
         input:
-          cmd: "wget -p /tmp/st2-up/ubuntu/trusty/ https://packagecloud.io/StackStorm/<% $.source %>/ubuntu/pool/trusty/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
+          cmd: "wget -O /tmp/st2-up/ubuntu/trusty/<% $.deb %> https://packagecloud.io/StackStorm/<% $.source %>/ubuntu/pool/trusty/main/<% $.package.substring(0,1) %>/<% $.package %>/<% $.deb %>"
         on-success: upload_trusty
+        on-error: cleanup
       upload_trusty:
         action: core.local
         input:
-          cmd: "package_cloud push StackStorm/<% $.repo %>/ubuntu/trusty /tmp/st2-up/ubuntu/trusty/<% $.deb %>"
+          cmd: "LANG=en_US.utf8 PACKAGECLOUD_TOKEN=<% $.token %> package_cloud push StackStorm/<% $.repo %>/ubuntu/trusty /tmp/st2-up/ubuntu/trusty/<% $.deb %>"
         on-success: cleanup
+        on-error: cleanup
 
       download_wheezy:
         action: core.local
         input:
-          cmd: "wget -p /tmp/st2-up/debian/wheezy/ https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/wheezy/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
+          cmd: "wget -O /tmp/st2-up/debian/wheezy/<% $.deb %> https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/wheezy/main/<% $.package.substring(0,1) %>/<% $.package %>/<% $.deb %>"
         on-success: upload_wheezy
+        on-error: cleanup
       upload_wheezy:
         action: core.local
         input:
-          cmd: "package_cloud push StackStorm/<% $.repo %>/debian/wheezy /tmp/st2-up/debian/wheezy/<% $.deb %>"
+          cmd: "LANG=en_US.utf8 PACKAGECLOUD_TOKEN=<% $.token %> package_cloud push StackStorm/<% $.repo %>/debian/wheezy /tmp/st2-up/debian/wheezy/<% $.deb %>"
         on-success: cleanup
+        on-error: cleanup
 
       download_jessie:
         action: core.local
         input:
-          cmd: "wget -p /tmp/st2-up/debian/jessie/ https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/jessie/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
+          cmd: "wget -O /tmp/st2-up/debian/jessie/<% $.deb %> https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/jessie/main/<% $.package.substring(0,1) %>/<% $.package %>/<% $.deb %>"
         on-success: upload_jessie
+        on-error: cleanup
       upload_jessie:
         action: core.local
         input:
-          cmd: "package_cloud push StackStorm/<% $.repo %>/debian/jessie /tmp/st2-up/debian/jessie/<% $.deb %>"
+          cmd: "LANG=en_US.utf8 PACKAGECLOUD_TOKEN=<% $.token %> package_cloud push StackStorm/<% $.repo %>/debian/jessie /tmp/st2-up/debian/jessie/<% $.deb %>"
         on-success: cleanup
-
-      download_el6:
-        action: core.local
-        input:
-          cmd: "wget -p /tmp/st2-up/el/6 https://packagecloud.io/StackStorm/<% $.source %>/el/6/<% $.package %>/<% $.rpm %>"
-        on-success: upload_el6
-      upload_el6:
-        action: core.local
-        input:
-          cmd: "package_cloud push StackStorm/<% $.repo %>/el/6 /tmp/st2-up/el/6/<% $.rpm %>"
-        on-success: cleanup
-
-      download_el7:
-        action: core.local
-        input:
-          cmd: "wget -p /tmp/st2-up/el/7 https://packagecloud.io/StackStorm/<% $.source %>/el/7/<% $.package %>/<% $.rpm %>"
-        on-success: upload_el6
-      upload_el7:
-        action: core.local
-        input:
-          cmd: "package_cloud push StackStorm/<% $.repo %>/el/7 /tmp/st2-up/el/7/<% $.rpm %>"
-        on-success: cleanup
+        on-error: cleanup
 
       cleanup:
         join: all

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -17,7 +17,7 @@ st2cd.promote_package:
         input:
           cmd: "mkdir -p /tmp/st2-up/{ubuntu/trusty,debian/wheezy,debian/jessie,el/6,el/7}"
         publish:
-          rpm: "<% $.package %>_<% $.version %>-<% $.revision %>.x86_64.rpm"
+          rpm: "<% $.package %>-<% $.version %>-<% $.revision %>.x86_64.rpm"
           deb: "<% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb"
           source: "<% $.repo = 'enterprise' and 'enterprise-staging' or $.repo = 'enterprise-unstable' and 'enterprise-staging-unstable' or $.repo = 'stable' and 'staging-stable' or $.repo = 'unstable' and 'staging-unstable' %>"
           token: ""
@@ -25,6 +25,8 @@ st2cd.promote_package:
           - download_trusty: "<% $.os in list('all', 'deb', 'trusty') %>"
           - download_wheezy: "<% $.os in list('all', 'deb', 'wheezy') %>"
           - download_jessie: "<% $.os in list('all', 'deb', 'jessie') %>"
+          - download_el6: "<% $.os in list('all', 'rpm', 'el6') %>"
+          - download_el7: "<% $.os in list('all', 'rpm', 'el7') %>"
 
       download_trusty:
         action: core.local
@@ -62,6 +64,32 @@ st2cd.promote_package:
         action: core.local
         input:
           cmd: "LANG=en_US.utf8 PACKAGECLOUD_TOKEN=<% $.token %> package_cloud push StackStorm/<% $.repo %>/debian/jessie /tmp/st2-up/debian/jessie/<% $.deb %>"
+#        on-success: cleanup
+#        on-error: cleanup
+
+      download_el6:
+        action: core.local
+        input:
+          cmd: "wget -O /tmp/st2-up/el/6/<% $.rpm %> https://packagecloud.io/StackStorm/<% $.source %>/el/6/x86_64/<% $.rpm %>"
+        on-success: upload_el6
+#        on-error: cleanup
+      upload_el6:
+        action: core.local
+        input:
+          cmd: "LANG=en_US.utf8 PACKAGECLOUD_TOKEN=<% $.token %> package_cloud push StackStorm/<% $.repo %>/el/6 /tmp/st2-up/el/6/<% $.rpm %>"
+#        on-success: cleanup
+#        on-error: cleanup
+
+      download_el7:
+        action: core.local
+        input:
+          cmd: "wget -O /tmp/st2-up/el/7/<% $.rpm %> https://packagecloud.io/StackStorm/<% $.source %>/el/7/x86_64/<% $.rpm %>"
+        on-success: upload_el7
+#        on-error: cleanup
+      upload_el7:
+        action: core.local
+        input:
+          cmd: "LANG=en_US.utf8 PACKAGECLOUD_TOKEN=<% $.token %> package_cloud push StackStorm/<% $.repo %>/el/7 /tmp/st2-up/el/7/<% $.rpm %>"
 #        on-success: cleanup
 #        on-error: cleanup
 

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -1,3 +1,7 @@
+# TODO: handle 404
+# TODO: handle uninitialized package_cloud
+# TODO: handle success on every os (messages)
+
 ---
 version: '2.0'
 
@@ -5,86 +9,83 @@ st2cd.promote_package:
     description: Promote a package to production.
     type: direct
     input:
-        - package
-        - version
-        - revision
-        - os
-        - repo
+      - package
+      - version
+      - revision
+      - os
+      - repo
     tasks:
 
-        init:
-            action: core.local
-            input:
-                cmd: "mkdir -p /tmp/st2-up/{ubuntu/trusty,debian/wheezy,debian/jessie,el/6,el/7}"
-            publish:
-                trusty_path: ubuntu/trusty
-                wheezy_path: debian/wheezy
-                jessie_path: debian/jessie
-                el6_path:    el/6
-                el7_path:    el/7
-                rpm: <% $.package %>_<% $.version %>-<% $.revision %>.x86_64.rpm
-                deb: <% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb
-                source: <% $.repo = 'enterprise' and 'enterprise-staging' or $.repo = 'enterprise-unstable' and 'enterprise-staging-unstable' or $.repo = 'stable' and 'staging-stable' or $.repo = 'unstable' and 'staging-unstable' %>
-            on-success:
-                - download_trusty: "<% $.os in list(None, 'trusty') %>"
-                - download_wheezy: "<% $.os in list(None, 'wheezy') %>"
-                - download_jessie: "<% $.os in list(None, 'jessie') %>"
-                - download_el6: "<% $.os in list(None, 'el6') %>"
-                - download_el7: "<% $.os in list(None, 'el7') %>"
+      init:
+        action: core.local
+        input:
+          cmd: "mkdir -p /tmp/st2-up/{ubuntu/trusty,debian/wheezy,debian/jessie,el/6,el/7}"
+        publish:
+          el6_path:    el/6
+          el7_path:    el/7
+          rpm: <% $.package %>_<% $.version %>-<% $.revision %>.x86_64.rpm
+          deb: <% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb
+          source: <% $.repo = 'enterprise' and 'enterprise-staging' or $.repo = 'enterprise-unstable' and 'enterprise-staging-unstable' or $.repo = 'stable' and 'staging-stable' or $.repo = 'unstable' and 'staging-unstable' %>
+        on-success:
+          - download_trusty: "<% $.os in list(None, 'trusty') %>"
+          - download_wheezy: "<% $.os in list(None, 'wheezy') %>"
+          - download_jessie: "<% $.os in list(None, 'jessie') %>"
+          - download_el6: "<% $.os in list(None, 'el6') %>"
+          - download_el7: "<% $.os in list(None, 'el7') %>"
 
-        download_trusty:
-            action: core.local
-            input:
-                cmd: "wget -p /tmp/st2-up/<% $.trusty_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.trusty_path %>/<% $.deb %>"
-            on-success: upload_trusty
-        upload_trusty:
-            action: core.local
-            input:
-                cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.trusty_path %> /tmp/st2-up/<% $.trusty_path %>/<% $.deb %>"
-            on-success: cleanup
+      download_trusty:
+        action: core.local
+        input:
+            cmd: "wget -p /tmp/st2-up/ubuntu/trusty/ https://packagecloud.io/StackStorm/<% $.source %>/ubuntu/pool/trusty/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
+        on-success: upload_trusty
+      upload_trusty:
+        action: core.local
+        input:
+            cmd: "package_cloud push StackStorm/<% $.repo %>/ubuntu/trusty /tmp/st2-up/ubuntu/trusty/<% $.deb %>"
+        on-success: cleanup
 
-        download_wheezy:
-            action: core.local
-            input:
-                cmd: "wget -p /tmp/st2-up/<% $.wheezy_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.wheezy_path %>/<% $.deb %>"
-            on-success: upload_wheezy
-        upload_wheezy:
-            action: core.local
-            input:
-                cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.wheezy_path %> /tmp/st2-up/<% $.wheezy_path %>/<% $.deb %>"
-            on-success: cleanup
+      download_wheezy:
+        action: core.local
+        input:
+            cmd: "wget -p /tmp/st2-up/debian/wheezy/ https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/wheezy/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
+        on-success: upload_wheezy
+      upload_wheezy:
+        action: core.local
+        input:
+            cmd: "package_cloud push StackStorm/<% $.repo %>/debian/wheezy /tmp/st2-up/debian/wheezy/<% $.deb %>"
+        on-success: cleanup
 
         download_jessie:
             action: core.local
             input:
-                cmd: "wget -p /tmp/st2-up/<% $.jessie_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.jessie_path %>/<% $.deb %>"
+                cmd: "wget -p /tmp/st2-up/debian/jessie/ https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/jessie/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
             on-success: upload_jessie
         upload_jessie:
             action: core.local
             input:
-                cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.jessie_path %> /tmp/st2-up/<% $.jessie_path %>/<% $.deb %>"
+                cmd: "package_cloud push StackStorm/<% $.repo %>/debian/jessie /tmp/st2-up/debian/jessie/<% $.deb %>"
             on-success: cleanup
 
         download_el6:
             action: core.local
             input:
-                cmd: "wget -p /tmp/st2-up/<% $.el6_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.el6_path %>/<% $.rpm %>"
+                cmd: "wget -p /tmp/st2-up/el/6 https://packagecloud.io/StackStorm/<% $.source %>/el/6/<% $.package %>/<% $.rpm %>"
             on-success: upload_el6
         upload_el6:
             action: core.local
             input:
-                cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.el6_path %> /tmp/st2-up/<% $.el6_path %>/<% $.rpm %>"
+                cmd: "package_cloud push StackStorm/<% $.repo %>/el/6 /tmp/st2-up/el/6/<% $.rpm %>"
             on-success: cleanup
 
         download_el7:
             action: core.local
             input:
-                cmd: "wget -p /tmp/st2-up/<% $.el7_path %> https://packagecloud.io/stackstorm/<% $.source %>/<% $.el7_path %>/<% $.rpm %>"
-            on-success: upload_el7
+                cmd: "wget -p /tmp/st2-up/el/7 https://packagecloud.io/StackStorm/<% $.source %>/el/7/<% $.package %>/<% $.rpm %>"
+            on-success: upload_el6
         upload_el7:
             action: core.local
             input:
-                cmd: "package_cloud push StackStorm/<% $.repo %>/<% $.el7_path %> /tmp/st2-up/<% $.el7_path %>/<% $.rpm %>"
+                cmd: "package_cloud push StackStorm/<% $.repo %>/el/7 /tmp/st2-up/el/7/<% $.rpm %>"
             on-success: cleanup
 
         cleanup:

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -36,60 +36,60 @@ st2cd.promote_package:
       download_trusty:
         action: core.local
         input:
-            cmd: "wget -p /tmp/st2-up/ubuntu/trusty/ https://packagecloud.io/StackStorm/<% $.source %>/ubuntu/pool/trusty/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
+          cmd: "wget -p /tmp/st2-up/ubuntu/trusty/ https://packagecloud.io/StackStorm/<% $.source %>/ubuntu/pool/trusty/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
         on-success: upload_trusty
       upload_trusty:
         action: core.local
         input:
-            cmd: "package_cloud push StackStorm/<% $.repo %>/ubuntu/trusty /tmp/st2-up/ubuntu/trusty/<% $.deb %>"
+          cmd: "package_cloud push StackStorm/<% $.repo %>/ubuntu/trusty /tmp/st2-up/ubuntu/trusty/<% $.deb %>"
         on-success: cleanup
 
       download_wheezy:
         action: core.local
         input:
-            cmd: "wget -p /tmp/st2-up/debian/wheezy/ https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/wheezy/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
+          cmd: "wget -p /tmp/st2-up/debian/wheezy/ https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/wheezy/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
         on-success: upload_wheezy
       upload_wheezy:
         action: core.local
         input:
-            cmd: "package_cloud push StackStorm/<% $.repo %>/debian/wheezy /tmp/st2-up/debian/wheezy/<% $.deb %>"
+          cmd: "package_cloud push StackStorm/<% $.repo %>/debian/wheezy /tmp/st2-up/debian/wheezy/<% $.deb %>"
         on-success: cleanup
 
-        download_jessie:
-            action: core.local
-            input:
-                cmd: "wget -p /tmp/st2-up/debian/jessie/ https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/jessie/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
-            on-success: upload_jessie
-        upload_jessie:
-            action: core.local
-            input:
-                cmd: "package_cloud push StackStorm/<% $.repo %>/debian/jessie /tmp/st2-up/debian/jessie/<% $.deb %>"
-            on-success: cleanup
+      download_jessie:
+        action: core.local
+        input:
+          cmd: "wget -p /tmp/st2-up/debian/jessie/ https://packagecloud.io/StackStorm/<% $.source %>/debian/pool/jessie/main/<% $.package[0] %>/<% $.package %>/<% $.deb %>"
+        on-success: upload_jessie
+      upload_jessie:
+        action: core.local
+        input:
+          cmd: "package_cloud push StackStorm/<% $.repo %>/debian/jessie /tmp/st2-up/debian/jessie/<% $.deb %>"
+        on-success: cleanup
 
-        download_el6:
-            action: core.local
-            input:
-                cmd: "wget -p /tmp/st2-up/el/6 https://packagecloud.io/StackStorm/<% $.source %>/el/6/<% $.package %>/<% $.rpm %>"
-            on-success: upload_el6
-        upload_el6:
-            action: core.local
-            input:
-                cmd: "package_cloud push StackStorm/<% $.repo %>/el/6 /tmp/st2-up/el/6/<% $.rpm %>"
-            on-success: cleanup
+      download_el6:
+        action: core.local
+        input:
+          cmd: "wget -p /tmp/st2-up/el/6 https://packagecloud.io/StackStorm/<% $.source %>/el/6/<% $.package %>/<% $.rpm %>"
+        on-success: upload_el6
+      upload_el6:
+        action: core.local
+        input:
+          cmd: "package_cloud push StackStorm/<% $.repo %>/el/6 /tmp/st2-up/el/6/<% $.rpm %>"
+        on-success: cleanup
 
-        download_el7:
-            action: core.local
-            input:
-                cmd: "wget -p /tmp/st2-up/el/7 https://packagecloud.io/StackStorm/<% $.source %>/el/7/<% $.package %>/<% $.rpm %>"
-            on-success: upload_el6
-        upload_el7:
-            action: core.local
-            input:
-                cmd: "package_cloud push StackStorm/<% $.repo %>/el/7 /tmp/st2-up/el/7/<% $.rpm %>"
-            on-success: cleanup
+      download_el7:
+        action: core.local
+        input:
+          cmd: "wget -p /tmp/st2-up/el/7 https://packagecloud.io/StackStorm/<% $.source %>/el/7/<% $.package %>/<% $.rpm %>"
+        on-success: upload_el6
+      upload_el7:
+        action: core.local
+        input:
+          cmd: "package_cloud push StackStorm/<% $.repo %>/el/7 /tmp/st2-up/el/7/<% $.rpm %>"
+        on-success: cleanup
 
-        cleanup:
-            join: all
-            action: core.local
-            input:
-                cmd: "rm -rf /tmp/st2-up"
+      cleanup:
+        join: all
+        action: core.local
+        input:
+          cmd: "rm -rf /tmp/st2-up"

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -1,7 +1,3 @@
-# TODO: handle 404
-# TODO: handle uninitialized package_cloud
-# TODO: handle success on every os (messages)
-
 ---
 version: '2.0'
 

--- a/aliases/promote_package.yaml
+++ b/aliases/promote_package.yaml
@@ -3,6 +3,9 @@ name: "promote_package"
 pack: "st2cd"
 action_ref: "st2cd.promote_package"
 formats:
+  - display: "promote [deb|rpm] of [package] [version]-[revision] to [stable|unstable|enterprise|enterprise-unstable]"
+    representation:
+    - "promote {{os}} of {{package}} {{version}}-{{revision}} to {{repo}}"
   - display: "promote [package] [version]-[revision] for [wheezy|jessie|trusty|el6|el7] to [stable|unstable|enterprise|enterprise-unstable]"
     representation:
     - "promote {{package}} {{version}}-{{revision}} for {{os}} to {{repo}}"
@@ -11,62 +14,62 @@ formats:
     - "promote {{package}} {{version}}-{{revision}} to {{repo}}"
 description: "Promote a package to production repo"
 ack:
-  format: "Ack! Uploading your packages right now. {% if execution.parameters.os == 'all' %}This might take a while, I'm uploading them for every OS.{% endif %}"
+  format: "Ack! Uploading your packages right now. {% if not 'os' in execution.parameters %}This might take a while, I'm uploading them for every OS.{% endif %}"
 result:
   format: |
     I'm done promoting the packages. Here's how it went:{~}
     {% if 'download_wheezy' in execution.result.tasks|map(attribute='name') %}
-      *Wheezy*: {% if 'upload_wheezy' in execution.result.tasks|map(attribute='name') -%}
-          {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_wheezy")).next().result.succeeded -%}
-            success
-          {%- else -%}
-            upload failed
-          {%- endif -%}
+    *Wheezy*: {% if 'upload_wheezy' in execution.result.tasks|map(attribute='name') -%}
+        {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_wheezy")).next().result.succeeded -%}
+          success
         {%- else -%}
-          download failed
-        {%- endif -%}.
+          upload failed
+        {%- endif -%}
+      {%- else -%}
+        download failed
+      {%- endif -%}.
     {% endif %}
     {% if 'download_trusty' in execution.result.tasks|map(attribute='name') %}
-      *Trusty*: {% if 'upload_trusty' in execution.result.tasks|map(attribute='name') -%}
-          {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_trusty")).next().result.succeeded -%}
-            success
-          {%- else -%}
-            upload failed
-          {%- endif -%}
+    *Trusty*: {% if 'upload_trusty' in execution.result.tasks|map(attribute='name') -%}
+        {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_trusty")).next().result.succeeded -%}
+          success
         {%- else -%}
-          download failed
-        {%- endif -%}.
+          upload failed
+        {%- endif -%}
+      {%- else -%}
+        download failed
+      {%- endif -%}.
     {% endif %}
     {% if 'download_jessie' in execution.result.tasks|map(attribute='name') %}
-      *Jessie*: {% if 'upload_jessie' in execution.result.tasks|map(attribute='name') -%}
-          {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_jessie")).next().result.succeeded -%}
-            success
-          {%- else -%}
-            upload failed
-          {%- endif -%}
+    *Jessie*: {% if 'upload_jessie' in execution.result.tasks|map(attribute='name') -%}
+        {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_jessie")).next().result.succeeded -%}
+          success
         {%- else -%}
-          download failed
-        {%- endif -%}.
+          upload failed
+        {%- endif -%}
+      {%- else -%}
+        download failed
+      {%- endif -%}.
     {% endif %}
     {% if 'download_el6' in execution.result.tasks|map(attribute='name') %}
-      *RHEL6*: {% if 'upload_el6' in execution.result.tasks|map(attribute='name') -%}
-          {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_el6")).next().result.succeeded -%}
-            success
-          {%- else -%}
-            upload failed
-          {%- endif -%}
+    *RHEL6*: {% if 'upload_el6' in execution.result.tasks|map(attribute='name') -%}
+        {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_el6")).next().result.succeeded -%}
+          success
         {%- else -%}
-          download failed
-        {%- endif -%}.
+          upload failed
+        {%- endif -%}
+      {%- else -%}
+        download failed
+      {%- endif -%}.
     {% endif %}
     {% if 'download_el7' in execution.result.tasks|map(attribute='name') %}
-      *RHEL7*: {% if 'download_el7' in execution.result.tasks|map(attribute='name') -%}
-          {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_el7")).next().result.succeeded -%}
-            success
-          {%- else -%}
-            upload failed
-          {%- endif -%}
+    *RHEL7*: {% if 'download_el7' in execution.result.tasks|map(attribute='name') -%}
+        {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_el7")).next().result.succeeded -%}
+          success
         {%- else -%}
-          download failed
-        {%- endif -%}.
+          upload failed
+        {%- endif -%}
+      {%- else -%}
+        download failed
+      {%- endif -%}.
     {% endif %}

--- a/aliases/promote_package.yaml
+++ b/aliases/promote_package.yaml
@@ -10,3 +10,63 @@ formats:
     representation:
     - "promote {{package}} {{version}}-{{revision}} to {{repo}}"
 description: "Promote a package to production repo"
+ack:
+  format: "Ack! Uploading your packages right now. {% if execution.parameters.os is equalto 'all' %}This might take a while, I'm uploading them for every OS.{% endif %}"
+result:
+  format: |
+    I'm done promoting the packages. Here's how it went:{~}
+    {% if 'download_wheezy' in execution.result.tasks|map(attribute='name') %}
+      *Wheezy*: {% if 'upload_wheezy' in execution.result.tasks|map(attribute='name') -%}
+          {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_wheezy")).next().result.succeeded -%}
+            success
+          {%- else -%}
+            upload failed
+          {%- endif -%}
+        {%- else -%}
+          download failed
+        {%- endif -%}.
+    {% endif %}
+    {% if 'download_trusty' in execution.result.tasks|map(attribute='name') %}
+      *Trusty*: {% if 'upload_trusty' in execution.result.tasks|map(attribute='name') -%}
+          {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_trusty")).next().result.succeeded -%}
+            success
+          {%- else -%}
+            upload failed
+          {%- endif -%}
+        {%- else -%}
+          download failed
+        {%- endif -%}.
+    {% endif %}
+    {% if 'download_jessie' in execution.result.tasks|map(attribute='name') %}
+      *Jessie*: {% if 'upload_jessie' in execution.result.tasks|map(attribute='name') -%}
+          {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_jessie")).next().result.succeeded -%}
+            success
+          {%- else -%}
+            upload failed
+          {%- endif -%}
+        {%- else -%}
+          download failed
+        {%- endif -%}.
+    {% endif %}
+    {% if 'download_el6' in execution.result.tasks|map(attribute='name') %}
+      *RHEL6*: {% if 'upload_el6' in execution.result.tasks|map(attribute='name') -%}
+          {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_el6")).next().result.succeeded -%}
+            success
+          {%- else -%}
+            upload failed
+          {%- endif -%}
+        {%- else -%}
+          download failed
+        {%- endif -%}.
+    {% endif %}
+    {% if 'download_el7' in execution.result.tasks|map(attribute='name') %}
+      *RHEL7*: {% if 'download_el7' in execution.result.tasks|map(attribute='name') -%}
+          {% if- (execution.result.tasks|selectattr("name", "equalto", "upload_el7")).next().result.succeeded -%}
+            success
+          {%- else -%}
+            upload failed
+          {%- endif -%}
+        {%- else -%}
+          download failed
+        {%- endif -%}.
+    {% endif %}

--- a/aliases/promote_package.yaml
+++ b/aliases/promote_package.yaml
@@ -1,0 +1,12 @@
+---
+name: "promote_package"
+pack: "st2cd"
+action_ref: "st2cd.promote_package"
+formats:
+  - display: "promote [package] [version]-[revision] to [stable|unstable|enterprise|enterprise-unstable]"
+    representation:
+    - "promote {{package}} {{version}}-{{revision}} to {{repo}}"
+  - display: "promote [package] [version]-[revision] for [wheezy|jessie|trusty|el6|el7] to [stable|unstable|enterprise|enterprise-unstable]"
+    representation:
+    - "promote {{package}} {{version}}-{{revision}} for {{os}} to {{repo}}"
+description: "Promote a package to production repo"

--- a/aliases/promote_package.yaml
+++ b/aliases/promote_package.yaml
@@ -10,3 +10,23 @@ formats:
     representation:
     - "promote {{package}} {{version}}-{{revision}} to {{repo}}"
 description: "Promote a package to production repo"
+ack:
+  format: Ack! Uploading your packages right now. {% if !os %}This might take a while, I'm uploading a version for every OS.{% endif %}
+result:
+  format: |
+    I'm done promoting the packages. Here's how it went:{~}
+    {% if 'download_wheezy' in tasks|map(attribute='name') %}
+      Wheezy: {% if tasks|selectattr("name", "upload_wheezy").length %}{% if tasks|selectattr("name", "upload_wheezy")[0].result.succeeded %}success{% else %}upload failed{% endif %}{% else %}download failed{% endif %}.
+    {% endif %}
+    {% if 'download_jessie' in tasks|map(attribute='name') %}
+      Jessie: {% if tasks|selectattr("name", "upload_jessie").length %}{% if tasks|selectattr("name", "upload_jessie")[0].result.succeeded %}success{% else %}upload failed{% endif %}{% else %}download failed{% endif %}.
+    {% endif %}
+    {% if 'download_trusty' in tasks|map(attribute='name') %}
+      Trusty: {% if tasks|selectattr("name", "upload_trusty").length %}{% if tasks|selectattr("name", "upload_trusty")[0].result.succeeded %}success{% else %}upload failed{% endif %}{% else %}download failed{% endif %}.
+    {% endif %}
+    {% if 'download_el6' in tasks|map(attribute='name') %}
+      EL6: {% if tasks|selectattr("name", "upload_el6").length %}{% if tasks|selectattr("name", "upload_el6")[0].result.succeeded %}success{% else %}upload failed{% endif %}{% else %}download failed{% endif %}.
+    {% endif %}
+    {% if 'download_el7' in tasks|map(attribute='name') %}
+      EL7: {% if tasks|selectattr("name", "upload_el7").length %}{% if tasks|selectattr("name", "upload_el7")[0].result.succeeded %}success{% else %}upload failed{% endif %}{% else %}download failed{% endif %}.
+    {% endif %}

--- a/aliases/promote_package.yaml
+++ b/aliases/promote_package.yaml
@@ -3,10 +3,10 @@ name: "promote_package"
 pack: "st2cd"
 action_ref: "st2cd.promote_package"
 formats:
-  - display: "promote [package] [version]-[revision] to [stable|unstable|enterprise|enterprise-unstable]"
-    representation:
-    - "promote {{package}} {{version}}-{{revision}} to {{repo}}"
   - display: "promote [package] [version]-[revision] for [wheezy|jessie|trusty|el6|el7] to [stable|unstable|enterprise|enterprise-unstable]"
     representation:
     - "promote {{package}} {{version}}-{{revision}} for {{os}} to {{repo}}"
+  - display: "promote [package] [version]-[revision] to [stable|unstable|enterprise|enterprise-unstable]"
+    representation:
+    - "promote {{package}} {{version}}-{{revision}} to {{repo}}"
 description: "Promote a package to production repo"

--- a/aliases/promote_package.yaml
+++ b/aliases/promote_package.yaml
@@ -11,7 +11,7 @@ formats:
     - "promote {{package}} {{version}}-{{revision}} to {{repo}}"
 description: "Promote a package to production repo"
 ack:
-  format: "Ack! Uploading your packages right now. {% if execution.parameters.os is equalto 'all' %}This might take a while, I'm uploading them for every OS.{% endif %}"
+  format: "Ack! Uploading your packages right now. {% if execution.parameters.os == 'all' %}This might take a while, I'm uploading them for every OS.{% endif %}"
 result:
   format: |
     I'm done promoting the packages. Here's how it went:{~}


### PR DESCRIPTION
This is a WIP workflow for promoting packages from staging to prod. It accepts package, version, revision, os, and repo, generates the right download and upload URLs, and uploads the package for one or multiple OSes.

Right now it’s based on `package_cloud`, so it has to be installed on the machine. Also, the token has to go into the workflow.

It’s still WIP because RHEL isn’t working and error reporting could be better. Any other improvements you might have are greatly appreciated.

There’s also a neat chatops alias to go along with it.
