### PR TITLE
Rename st2_package_test to st2_pkg_test

### DIFF
--- a/actions/st2_pkg_test.meta.yaml
+++ b/actions/st2_pkg_test.meta.yaml
@@ -1,10 +1,10 @@
 ---
-name: st2_package_test
+name: st2_pkg_test
 pack: st2cd
 description: End to end test for st2 package
 enabled: true
 runner_type: mistral-v2
-entry_point: workflows/st2_package_test.yaml
+entry_point: workflows/st2_pkg_test.yaml
 parameters:
     hostname:
         type: string

--- a/actions/workflows/st2_pkg_test.yaml
+++ b/actions/workflows/st2_pkg_test.yaml
@@ -1,7 +1,7 @@
 ---
 version: '2.0'
 
-st2cd.st2_package_test:
+st2cd.st2_pkg_test:
     type: direct
     input:
         - hostname
@@ -107,7 +107,7 @@ st2cd.st2_package_test:
             input:
                 channel: "#thunderdome"
                 text: ""
-                attachments: '[{"title": "[st2cd.st2_package_test: STARTED]", "title_link": "<% $.webui_base_url %>/#/history/<% env().st2_execution_id %>/general", "text": "HOSTNAME: <% $.vm_fqdn %>\nBOOTSTRAP: <% $.bootstrap_script_url %>\nDISTRO: <% $.distro %>\nRELEASE: <% $.release %>\nVERSION: <% coalesce($.version, ''latest'') %>", "color": "#808080"}]'
+                attachments: '[{"title": "[st2cd.st2_pkg_test: STARTED]", "title_link": "<% $.webui_base_url %>/#/history/<% env().st2_execution_id %>/general", "text": "HOSTNAME: <% $.vm_fqdn %>\nBOOTSTRAP: <% $.bootstrap_script_url %>\nDISTRO: <% $.distro %>\nRELEASE: <% $.release %>\nVERSION: <% coalesce($.version, ''latest'') %>", "color": "#808080"}]'
 
 
         destroy_vm:
@@ -121,7 +121,7 @@ st2cd.st2_package_test:
             input:
                 channel: "#thunderdome"
                 text: ""
-                attachments: '[{"title": "[st2cd.st2_package_test: SUCCEEDED]", "title_link": "<% $.webui_base_url %>/#/history/<% env().st2_execution_id %>/general", "text": "HOSTNAME: <% $.vm_fqdn %>\nBOOTSTRAP: <% $.bootstrap_script_url %>\nDISTRO: <% $.distro %>\nRELEASE: <% $.release %>\nVERSION: <% coalesce($.version, ''latest'') %>\nVERSION INSTALLED:\n\t<% $.installed.version_str %>", "color": "#008000"}]'
+                attachments: '[{"title": "[st2cd.st2_pkg_test: SUCCEEDED]", "title_link": "<% $.webui_base_url %>/#/history/<% env().st2_execution_id %>/general", "text": "HOSTNAME: <% $.vm_fqdn %>\nBOOTSTRAP: <% $.bootstrap_script_url %>\nDISTRO: <% $.distro %>\nRELEASE: <% $.release %>\nVERSION: <% coalesce($.version, ''latest'') %>\nVERSION INSTALLED:\n\t<% $.installed.version_str %>", "color": "#008000"}]'
 
 
         destroy_vm_on_failure:
@@ -136,6 +136,6 @@ st2cd.st2_package_test:
             input:
                 channel: <% $.channel %>
                 text: ""
-                attachments: '[{"title": "[st2cd.st2_package_test: FAILED]", "title_link": "<% $.webui_base_url %>/#/history/<% env().st2_execution_id %>/general", "text": "HOSTNAME: <% $.vm_fqdn %>\nBOOTSTRAP: <% $.bootstrap_script_url %>\nDISTRO: <% $.distro %>\nRELEASE: <% $.release %>\nVERSION: <% coalesce($.version, ''latest'') %>\nVERSION INSTALLED:\n\t<% $.installed.version_str %>", "color": "#FF0000"}]'
+                attachments: '[{"title": "[st2cd.st2_pkg_test: FAILED]", "title_link": "<% $.webui_base_url %>/#/history/<% env().st2_execution_id %>/general", "text": "HOSTNAME: <% $.vm_fqdn %>\nBOOTSTRAP: <% $.bootstrap_script_url %>\nDISTRO: <% $.distro %>\nRELEASE: <% $.release %>\nVERSION: <% coalesce($.version, ''latest'') %>\nVERSION INSTALLED:\n\t<% $.installed.version_str %>", "color": "#FF0000"}]'
             on-complete:
                 - fail

--- a/rules/st2_pkg_test_timer_stable_rhel6.yaml
+++ b/rules/st2_pkg_test_timer_stable_rhel6.yaml
@@ -1,7 +1,7 @@
 ---
-name: st2_package_test_timer_stable_rhel6
+name: st2_pkg_test_timer_stable_rhel6
 pack: "st2cd"
-description: Run st2_package_test on timer for stable packages
+description: Run st2_pkg_test on timer for stable packages
 enabled: true
 
 trigger:
@@ -13,7 +13,7 @@ trigger:
 criteria: {}
 
 action:
-  ref: st2cd.st2_package_test
+  ref: st2cd.st2_pkg_test
   parameters:
     hostname: st2-pkg-stable-el6
     distro: RHEL6

--- a/rules/st2_pkg_test_timer_stable_rhel7.yaml
+++ b/rules/st2_pkg_test_timer_stable_rhel7.yaml
@@ -1,7 +1,7 @@
 ---
-name: st2_package_test_timer_stable_rhel7
+name: st2_pkg_test_timer_stable_rhel7
 pack: "st2cd"
-description: Run st2_package_test on timer for stable packages
+description: Run st2_pkg_test on timer for stable packages
 enabled: true
 
 trigger:
@@ -13,7 +13,7 @@ trigger:
 criteria: {}
 
 action:
-  ref: st2cd.st2_package_test
+  ref: st2cd.st2_pkg_test
   parameters:
     hostname: st2-pkg-stable-el7
     distro: RHEL7

--- a/rules/st2_pkg_test_timer_stable_u14.yaml
+++ b/rules/st2_pkg_test_timer_stable_u14.yaml
@@ -1,7 +1,7 @@
 ---
-name: st2_package_test_timer_stable_u14
+name: st2_pkg_test_timer_stable_u14
 pack: "st2cd"
-description: Run st2_package_test on timer for stable packages
+description: Run st2_pkg_test on timer for stable packages
 enabled: true
 
 trigger:
@@ -13,7 +13,7 @@ trigger:
 criteria: {}
 
 action:
-  ref: st2cd.st2_package_test
+  ref: st2cd.st2_pkg_test
   parameters:
     hostname: st2-pkg-stable-u14
     distro: UBUNTU14


### PR DESCRIPTION
Rename st2_package_test to st2_pkg_test to stay consistent with existing naming convention for other package related actions.
