### PR TITLE
Feeding packagecloud token to promotion workflow

### DIFF
--- a/actions/promote_package.yaml
+++ b/actions/promote_package.yaml
@@ -8,6 +8,7 @@ parameters:
   token:
     type: string
     description: Packagecloud API token
+    default: "{{system.pkg_cloud_token}}"
   package:
     type: string
     description: Package to promote

--- a/actions/promote_package.yaml
+++ b/actions/promote_package.yaml
@@ -5,6 +5,9 @@ description: Promote a package to production from staging.
 enabled: true
 entry_point: workflows/promote_package.yaml
 parameters:
+  token:
+    type: string
+    description: Packagecloud API token
   package:
     type: string
     description: Package to promote

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -10,6 +10,7 @@ st2cd.promote_package:
       - revision
       - os
       - repo
+      - token
     tasks:
 
       init:
@@ -20,7 +21,20 @@ st2cd.promote_package:
           rpm: "<% $.package %>-<% $.version %>-<% $.revision %>.x86_64.rpm"
           deb: "<% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb"
           source: "<% $.repo = 'enterprise' and 'enterprise-staging' or $.repo = 'enterprise-unstable' and 'enterprise-staging-unstable' or $.repo = 'stable' and 'staging-stable' or $.repo = 'unstable' and 'staging-unstable' %>"
-          token: ""
+        on-success:
+          - get_token: "<% $.token == '' %>"
+          - download_trusty: "<% $.token != '' and $.os in list('all', 'deb', 'trusty') %>"
+          - download_wheezy: "<% $.token != '' $.os in list('all', 'deb', 'wheezy') %>"
+          - download_jessie: "<% $.token != '' $.os in list('all', 'deb', 'jessie') %>"
+          - download_el6: "<% $.token != '' $.os in list('all', 'rpm', 'el6') %>"
+          - download_el7: "<% $.token != '' $.os in list('all', 'rpm', 'el7') %>"
+
+      get_token:
+        action: core.kv_get
+        input:
+          key: "packagecloud_token"
+        publish:
+          token: <% $.get_token.result %>
         on-success:
           - download_trusty: "<% $.os in list('all', 'deb', 'trusty') %>"
           - download_wheezy: "<% $.os in list('all', 'deb', 'wheezy') %>"

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -22,20 +22,6 @@ st2cd.promote_package:
           deb: "<% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb"
           source: "<% $.repo = 'enterprise' and 'enterprise-staging' or $.repo = 'enterprise-unstable' and 'enterprise-staging-unstable' or $.repo = 'stable' and 'staging-stable' or $.repo = 'unstable' and 'staging-unstable' %>"
         on-success:
-          - get_token: "<% $.token = '' %>"
-          - download_trusty: "<% $.token != '' and $.os in list('all', 'deb', 'trusty') %>"
-          - download_wheezy: "<% $.token != '' and $.os in list('all', 'deb', 'wheezy') %>"
-          - download_jessie: "<% $.token != '' and $.os in list('all', 'deb', 'jessie') %>"
-          - download_el6: "<% $.token != '' and $.os in list('all', 'rpm', 'el6') %>"
-          - download_el7: "<% $.token != '' and $.os in list('all', 'rpm', 'el7') %>"
-
-      get_token:
-        action: st2.kv.get
-        input:
-          key: "packagecloud_token"
-        publish:
-          token: <% $.get_token.result %>
-        on-success:
           - download_trusty: "<% $.os in list('all', 'deb', 'trusty') %>"
           - download_wheezy: "<% $.os in list('all', 'deb', 'wheezy') %>"
           - download_jessie: "<% $.os in list('all', 'deb', 'jessie') %>"

--- a/actions/workflows/promote_package.yaml
+++ b/actions/workflows/promote_package.yaml
@@ -22,15 +22,15 @@ st2cd.promote_package:
           deb: "<% $.package %>_<% $.version %>-<% $.revision %>_amd64.deb"
           source: "<% $.repo = 'enterprise' and 'enterprise-staging' or $.repo = 'enterprise-unstable' and 'enterprise-staging-unstable' or $.repo = 'stable' and 'staging-stable' or $.repo = 'unstable' and 'staging-unstable' %>"
         on-success:
-          - get_token: "<% $.token == '' %>"
+          - get_token: "<% $.token = '' %>"
           - download_trusty: "<% $.token != '' and $.os in list('all', 'deb', 'trusty') %>"
-          - download_wheezy: "<% $.token != '' $.os in list('all', 'deb', 'wheezy') %>"
-          - download_jessie: "<% $.token != '' $.os in list('all', 'deb', 'jessie') %>"
-          - download_el6: "<% $.token != '' $.os in list('all', 'rpm', 'el6') %>"
-          - download_el7: "<% $.token != '' $.os in list('all', 'rpm', 'el7') %>"
+          - download_wheezy: "<% $.token != '' and $.os in list('all', 'deb', 'wheezy') %>"
+          - download_jessie: "<% $.token != '' and $.os in list('all', 'deb', 'jessie') %>"
+          - download_el6: "<% $.token != '' and $.os in list('all', 'rpm', 'el6') %>"
+          - download_el7: "<% $.token != '' and $.os in list('all', 'rpm', 'el7') %>"
 
       get_token:
-        action: core.kv_get
+        action: st2.kv.get
         input:
           key: "packagecloud_token"
         publish:


### PR DESCRIPTION
As @m4dcoder requested, either specifying the token as a parameter or getting it from the KV store.
