### PR TITLE
VM creation alias: Better handling of DNS zones

### DIFF
--- a/actions/workflows/create_vm_role.yaml
+++ b/actions/workflows/create_vm_role.yaml
@@ -56,6 +56,8 @@
         name: "{{hostname}}.{{dns_zone}}"
         value: "{{ec2_instance_private_dns}}"
         zone: "{{dns_zone}}"
+      publish:
+        cname: "{{hostname}}.{{dns_zone}}"
       on-success: "get_distro"
     -
       name: "get_distro"

--- a/aliases/createvm.yaml
+++ b/aliases/createvm.yaml
@@ -13,11 +13,22 @@ result:
   format: |
     {% if execution.status == 'succeeded' -%}
     your VM is ready! You can now log in, all of the Stormers' accounts and keys are already there. Welcome!{~}
-    Hostname: {{ execution.parameters.hostname }}.{{ execution.parameters.dns_zone }}.
+    Hostname: {{ execution.parameters.hostname }}.
+      {%- if 'dns_zone' in execution.parameters -%}
+        {{ execution.parameters.dns_zone }}
+      {%- else -%}
+        {{ execution.action.parameters.dns_zone.default }}
+      {%- endif -%}.
     Instance type: `{{execution.parameters.instance_type }}`.
     Purpose: {{ execution.parameters.purpose }}.
     Puppet role: {{ execution.parameters.role }}.
-    ```ssh {{ execution.parameters.hostname }}.{{ execution.parameters.dns_zone }}```
+    ```ssh {{ execution.parameters.hostname }}.
+      {%- if 'dns_zone' in execution.parameters -%}
+        {{ execution.parameters.dns_zone }}
+      {%- else -%}
+        {{ execution.action.parameters.dns_zone.default }}
+      {%- endif -%}
+    ```
     {%- else -%}
     something went wrong during VM creation! Please check the execution data:{~}
     {{ execution }}


### PR DESCRIPTION
If a DNS zone is not specified and left to default, it won’t be rendered, so catching this in the alias.

Which also leads me to think that we should include parameters in the execution context even if they’re set to default (it actually came as a surprise that we don’t), but that’s a story for another day.
