### PR TITLE
Dynamically assign unique VM name

### DIFF
--- a/rules/st2_pkg_test_unstable_u14.yaml
+++ b/rules/st2_pkg_test_unstable_u14.yaml
@@ -18,6 +18,6 @@ action:
     ref: st2cd.st2_pkg_e2e_test
     parameters:
         distro: UBUNTU14
-        hostname: st2-pkg-test-unstable-u14
+        hostname: "st2-pkg-unstable-u14-{{trigger.body.payload.vcs_revision | truncate(10, False, '')}}"
         release: unstable
-        triggering_commit_url: "{{trigger.body.payload.all_commit_details[0].commit_url}}"
+        triggering_commit_url: "{{trigger.body.payload.vcs_url}}/commit/{{trigger.body.payload.vcs_revision}}"


### PR DESCRIPTION
Make VM name unique since more than one workflow instances of st2_pkg_e2e_test from the same trigger type can be running.
