### PR TITLE
Add missing tests from st2tests to e2e

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -191,7 +191,27 @@ workflows:
                     env: <% $.env %>
                     cmd: st2 run tests.test_quickstart_python_actions <% $.st2_cli_args %>
                     timeout: 600
-
+            test_quickstart_key_triggers:
+                action: core.remote
+                input:
+                    hosts: <% $.host %>
+                    env: <% $.env %>
+                    cmd: st2 run tests.test_key_triggers <% $.st2_cli_args %>
+                    timeout: 600
+            test_quickstart_trace:
+                action: core.remote
+                input:
+                    hosts: <% $.host %>
+                    env: <% $.env %>
+                    cmd: st2 run tests.test_quickstart_trace <% $.st2_cli_args %>
+                    timeout: 600
+            test_quickstart_timer_rules:
+                action: core.remote
+                input:
+                    hosts: <% $.host %>
+                    env: <% $.env %>
+                    cmd: st2 run tests.test_timer_rule <% $.st2_cli_args %>
+                    timeout: 600
 
     test_mistral:
         type: direct


### PR DESCRIPTION
Some of the tests in https://github.com/StackStorm/st2tests/tree/master/packs/tests were not added to e2e which resulted in test coverage holes. 

Let's wait until 1.5 release and merge this. 
