### PR TITLE
If version is None, set it to empty

### DIFF
--- a/actions/st2_upgrade_to_enterprise.sh
+++ b/actions/st2_upgrade_to_enterprise.sh
@@ -13,6 +13,10 @@ LDAP_BASE_OU=$9
 LDAP_GROUP_DN=${10}
 REPO=enterprise
 
+if [[ $VERSION="None" ]]; then
+    VERSION=''
+fi
+
 if [ "${PKG_ENV}" = "staging" ]; then
     REPO="${PKG_ENV}-${REPO}"
 fi


### PR DESCRIPTION
https://github.com/StackStorm/st2cd/blob/master/actions/st2_upgrade_to_enterprise.meta.yaml#L36. We apparently send “None” as positional argument if version is supplied.

This makes sense from system perspective because there are other pos args that follow with actual values but I was expecting ‘’ inside the script.

Sample log:

```
cd /tmp && /home/stanley/57871e6682fb9b2df9f0ecac/st2_upgrade_to_enterprise.sh <license_key
_redacted> UBUNTU14 unstable staging None 10.0.1.190 cn=Administrator,cn=users,dc=stackstorm,dc=net 94756a833cb362cddf7dbe78c60c4f0300138c8c@ dc=stackstorm,dc=net CN=testers,OU=groups,DC=stackstorm,DC=net'
```
