### PR TITLE
Append hostname to end of 127.0.0.1 localhost in /etc/hosts

### DIFF
--- a/actions/set_hostname.sh
+++ b/actions/set_hostname.sh
@@ -19,9 +19,11 @@ if [[ ! ${SUPPORTED_DISTROS[@]} =~ (^| )${DISTRO_LCASE}($| ) ]]; then
 fi
 
 if [[ ${DISTRO_LCASE} = "ubuntu" ]]; then
-    sed -i -e "s/\(preserve_hostname: \)false/\1true/" /etc/cloud/cloud.cfg && echo "${HOSTNAME}" > /etc/hostname && hostname ${HOSTNAME} && echo "127.0.0.1 ${HOSTNAME}" >> /etc/hosts
+    sed -i -e "s/\(preserve_hostname: \)false/\1true/" /etc/cloud/cloud.cfg && echo "${HOSTNAME}" > /etc/hostname && hostname ${HOSTNAME}
 elif [[ ${DISTRO_LCASE} = "redhat" || ${DISTRO_LCASE} = "centos" ]]; then
-    sed -i -e "s/\(HOSTNAME=\).*/\1${HOSTNAME}/" /etc/sysconfig/network && hostname ${HOSTNAME} && echo "127.0.0.1 ${HOSTNAME}" >> /etc/hosts
+    sed -i -e "s/\(HOSTNAME=\).*/\1${HOSTNAME}/" /etc/sysconfig/network && hostname ${HOSTNAME}
 elif [[ ${DISTRO_LCASE} = "fedora" ]]; then
-    echo -e "HOSTNAME=${HOSTNAME}" >> /etc/sysconfig/network && hostname ${HOSTNAME} && echo "127.0.0.1 ${HOSTNAME}" >> /etc/hosts
+    echo -e "HOSTNAME=${HOSTNAME}" >> /etc/sysconfig/network && hostname ${HOSTNAME}
 fi
+
+sed -i "/127\.0\.0\.1/ s/$/ ${HOSTNAME}/" /etc/hosts


### PR DESCRIPTION
http://stackoverflow.com/questions/8625029/why-does-pythons-socket-getfqdn-return-a-long-string-that-looks-like-an-ipv6

```
stanley@st2-ent-pkg-stable-u14:~$ cat /etc/hosts
127.0.0.1 localhost

# The following lines are desirable for IPv6 capable hosts
::1 ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
ff02::3 ip6-allhosts
127.0.0.1 st2-ent-pkg-stable-u14.uswest2.stackstorm.net
stanley@st2-ent-pkg-stable-u14:~$
```

Two entries for 127.0.0.1 in two different lines. So socket.getfqdn() returns the first one.

```
stanley@st2-ent-pkg-stable-u14:~$ cat /etc/hosts
127.0.0.1 localhost st2-ent-pkg-stable-u14.uswest2.stackstorm.net
```

fixes it.
