### PR TITLE
As part of finalize release, set st2_stable_version in datastore

### DIFF
--- a/actions/workflows/st2_finalize_release.yaml
+++ b/actions/workflows/st2_finalize_release.yaml
@@ -20,6 +20,7 @@ st2cd.st2_finalize_release:
             publish:
                 local_repo_sfx: <% task(init).result.stdout %>
                 next_patch_version: <% $.version.split('.')[0] + '.' + $.version.split('.')[1] + '.' + str(int($.version.split('.')[2]) + 1) %>
+                major_minor_version: <% $.version.split('.')[0] + '.' + $.version.split('.')[1] %>
             on-success:
                 - get_host: <% $.host = null %>
                 - finalize: <% $.host != null %>
@@ -39,7 +40,17 @@ st2cd.st2_finalize_release:
 
         finalize:
             on-complete:
+                - set_stable_version_datastore
+
+        set_stable_version_datastore:
+            action: st2cd.kvstore
+            input:
+                action: "update"
+                key: "st2_stable_version"
+                value: <% $.major_minor_version %>
+            on-success:
                 - make_st2docs_stable
+
         make_st2docs_stable:
             action: st2cd.st2_make_docs
             input:


### PR DESCRIPTION
Turns out docs release on commits requires us to set st2_stable_version key to {{major}}.{{minor}} in datastore. See https://github.com/StackStorm/st2cd/blob/master/actions/workflows/st2_docs.yaml#L54 . 

I fixed it by hand for 1.6 and I am opening this PR for future releases. Sample run of step I added:

```
lakshmi@st2-build-node-1:~$ st2 run st2cd.kvstore action=update key=st2_stable_version value=1.6
.
id: 57a8a71027263a708de3e75b
status: succeeded
parameters:
  action: update
  key: st2_stable_version
  value: '1.6'
result:
  exit_code: 0
  result:
    encrypted: false
    name: st2_stable_version
    scope: system
    secret: false
    uid: key_value_pair:system:st2_stable_version
    value: '1.6'
  stderr: ''
  stdout: ''
lakshmi@st2-build-node-1:~$

```
