### PR TITLE
Allow boxes to be spun up in 'public' subnet

### DIFF
--- a/actions/create_vm_role.meta.yaml
+++ b/actions/create_vm_role.meta.yaml
@@ -17,6 +17,7 @@
         - "production"
         - "staging"
         - "sandbox"
+        - "public"  # Use this if you want node to be available on public internet. Set up Elastic IP manually.
     key_name:
       type: "string"
       description: "SSH key to use during intial instance creation"


### PR DESCRIPTION
Sometimes we want the ability to spin a node in public subnet to share the box with someone else or just expose a demo node. This PR allows one to specify a "public" environment. We detect the subnet based off that key. The subnet id is set correctly in st2-build. 
