### PR TITLE
Fix trigger names - on new build server they are all lowercase

### DIFF
--- a/actions/create_docs_test_rule.py
+++ b/actions/create_docs_test_rule.py
@@ -66,7 +66,7 @@ def main(args):
         'description': 'Run docs build on each commit to branch.',
         'enabled': True,
         'trigger': {
-            'type': 'GitHubWebhook.github_event'
+            'type': 'githubwebhook.github_event'
         },
         'criteria': {
             'trigger.body.ref': {

--- a/actions/create_version_release_rule.py
+++ b/actions/create_version_release_rule.py
@@ -66,7 +66,7 @@ def main(args):
         'description': 'Run pytests on each commit to branch.',
         'enabled': True,
         'trigger': {
-            'type': 'GitHubWebhook.github_event'
+            'type': 'githubwebhook.github_event'
         },
         'criteria': {
             'trigger.body.ref': {

--- a/rules/st2_docs_prod.yaml
+++ b/rules/st2_docs_prod.yaml
@@ -3,7 +3,7 @@
     description: "Build st2 packages after tests succeed and push them to staging"
     enabled: true
     trigger:
-        type: "GitHubWebhook.github_event"
+        type: "githubwebhook.github_event"
     criteria:
         trigger.body.ref:
             pattern: "refs/heads/master"

--- a/rules/st2_docs_v14.yaml
+++ b/rules/st2_docs_v14.yaml
@@ -3,7 +3,7 @@
     description: "Build st2 packages after tests succeed and push them to production"
     enabled: true
     trigger:
-        type: "GitHubWebhook.github_event"
+        type: "githubwebhook.github_event"
     criteria:
         trigger.body.ref:
             pattern: "refs/heads/v1.4"

--- a/rules/st2_docs_v15.yaml
+++ b/rules/st2_docs_v15.yaml
@@ -3,7 +3,7 @@
     description: "Build st2 docs for StackStorm v1.5"
     enabled: true
     trigger:
-        type: "GitHubWebhook.github_event"
+        type: "githubwebhook.github_event"
     criteria:
         trigger.body.ref:
             pattern: "refs/heads/v1.5"

--- a/rules/st2_docs_v16.yaml
+++ b/rules/st2_docs_v16.yaml
@@ -3,7 +3,7 @@
     description: "Build st2 docs for StackStorm v1.6"
     enabled: true
     trigger:
-        type: "GitHubWebhook.github_event"
+        type: "githubwebhook.github_event"
     criteria:
         trigger.body.ref:
             pattern: "refs/heads/v1.6"

--- a/rules/st2cd_slack_github_push_master.yaml
+++ b/rules/st2cd_slack_github_push_master.yaml
@@ -3,7 +3,7 @@
     description: "Post to Slack on matching GitHub event"
     enabled: true
     trigger:
-        type: "GitHubWebhook.github_event"
+        type: "githubwebhook.github_event"
     criteria:
         trigger.body.ref:
             pattern: "refs/heads/master"

--- a/rules/st2contrib_regenerate_readme.yaml
+++ b/rules/st2contrib_regenerate_readme.yaml
@@ -3,7 +3,7 @@
     description: "Re-generate README.md on push to master in st2contrib"
     enabled: true
     trigger:
-        type: "GitHubWebhook.github_event"
+        type: "githubwebhook.github_event"
     criteria:
         trigger.body.ref:
             pattern: "refs/heads/master"


### PR DESCRIPTION
The title says it all, new build server is still missing a bunch of rules.
