### PR TITLE
Change the version to valid semver

### DIFF
--- a/pack.yaml
+++ b/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : st2cd
 description : pack of actions specifically created for the continuous delivery pipeline at StackStorm
-version : 0.1
+version : 0.1.0
 author : st2-dev
 email : info@stackstorm.com


### PR DESCRIPTION
As Winson pointed out, we don't have a semver string here and in st2ci, but it's assumed in the current pack management codebase.