### PR TITLE
docs not minor versioned for bwc

### DIFF
--- a/actions/workflows/bwc_docs.yaml
+++ b/actions/workflows/bwc_docs.yaml
@@ -26,7 +26,7 @@
       ref: "core.remote"
       params:
         hosts: "{{build_server}}"
-        cmd: "cd /tmp/{{repodir}} && cat version.txt"
+        cmd: "cd /tmp/{{repodir}} && cat version.txt | cut -d '.' -f 1-2"
       publish:
         version: "{{version[build_server].stdout | replace('\n', '')}}"
       on-success: "make_bwcdocs"


### PR DESCRIPTION
Same change as #219, but for BWC docs.

Problem is that if we have BWC v2.0.1, and we update docs, it does not trigger docs rebuild/push to S3. Docs only have x.y versioning, not x.y.z.

Thoughts @lakshmi-kannan ?