### PR TITLE
Add st2ctl reload in setup_e2e_tests

### DIFF
--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -35,6 +35,10 @@ sudo bash -c "cat <<keyvalue_options >>${ST2_CONF}
 encryption_key_path=${CRYPTO_KEY_FILE}
 keyvalue_options"
 
+# Reload required for testing st2 upgrade
+st2ctl reload --register-all
+
+# Install packs for testing
 if [[ ${BRANCH} == "master" ]]; then
     echo "Installing st2tests from '${BRANCH}' branch at location: `pwd`..."
     git clone -b ${BRANCH} --depth 1 https://github.com/StackStorm/st2tests.git


### PR DESCRIPTION
A reload is required for testing st2 upgrades. Otherwise, pluggable runners and pack management features will not work.