### PR TITLE
[st2cd.docs] Clean repo on failure

### DIFF
--- a/actions/workflows/bwc_docs.yaml
+++ b/actions/workflows/bwc_docs.yaml
@@ -30,6 +30,7 @@
       publish:
         version: "{{version[build_server].stdout | replace('\n', '')}}"
       on-success: "make_bwcdocs"
+      on-failure: "clean_repo"
     -
       name: "make_bwcdocs"
       ref: "core.remote"
@@ -38,6 +39,7 @@
         timeout: 2000
         cmd: "cd {{repodir}} && make bwcdocs"
       on-success: "s3cmd_docs"
+      on-failure: "clean_repo"
     -
       name: "s3cmd_docs"
       ref: "st2cd.s3_docs"
@@ -48,6 +50,7 @@
         bucket: "{{docs_url}}"
         version: "/{{version}}/"
       on-success: "clean_repo"
+      on-failure: "clean_repo"
     -
       name: "clean_repo"
       ref: "st2cd.git_clean"

--- a/actions/workflows/st2_docs.yaml
+++ b/actions/workflows/st2_docs.yaml
@@ -30,6 +30,7 @@
       publish:
         version: "{{version[build_server].stdout | replace('\n', '')}}"
       on-success: "update_url"
+      on-failure: "clean_repo"
     -
       name: "update_url"
       ref: "core.remote"
@@ -37,6 +38,7 @@
         hosts: "{{build_server}}"
         cmd: "cd /tmp/{{repodir}} && {% if environment == 'production' %}echo 'Production URL is correct in code' {% else %}sed -e 's~docs\\.stackstorm\\.com~{{docs_url}}~g' docs/source/conf.py {% endif %}"
       on-success: "make_docs"
+      on-failure: "clean_repo"
     -
       name: "make_docs"
       ref: "st2cd.make_docs"
@@ -45,6 +47,7 @@
         repo: "{{repodir}}"
         timeout: 1000
       on-success: "s3cmd_docs"
+      on-failure: "clean_repo"
     -
       name: "s3cmd_docs"
       ref: "st2cd.s3_docs"
@@ -55,6 +58,7 @@
         bucket: "{% if environment == 'production' %}docs.stackstorm.com{% else %}{{docs_url}}{% endif %}"
         version: "/{{version}}/"
       on-success: "clean_repo"
+      on-failure: "clean_repo"
     -
       name: "clean_repo"
       ref: "st2cd.git_clean"


### PR DESCRIPTION
The tasks don't clean up after themselves on failure which means disk space doesn't get free and when using small disks like we do (7 GB) it will run out of space sooner or later.