### PR TITLE
Use a more reliable external service url

### DIFF
--- a/actions/workflows/e2e_tests.yaml
+++ b/actions/workflows/e2e_tests.yaml
@@ -77,7 +77,7 @@
         name: "core_http_google"
         token: "{{st2_token}}"
         action: "core.http"
-        params: "url=http://www.marshmallowkittens.org"
+        params: "url=https://www.google.com"
         hosts: "{{hostname}}"
       on-success: "core_remote_single_host"
     -


### PR DESCRIPTION
marshmallowkittens.org is offline and causing our e2e tests to fail.

Relying on external service is not ideal, but google should be more reliable.