### PR TITLE
Remove another marshmallowkittens and implement robot mistral tests

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -115,7 +115,7 @@ workflows:
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
-                    cmd: st2 run core.http url=http://www.marshmallowkittens.org
+                    cmd: st2 run core.http url=https://google.com
             test_core_remote_single_host:
                 action: core.remote
                 input:

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -76,15 +76,15 @@ workflows:
                     env: <% $.st2_cli_env %>
                     cmd: cd /tmp/st2tests && . venv/bin/activate && pybot robotfm_tests/docs/
                     timeout: 500
-                # on-success:
-                    # - robot_mistral_tests
-                # robot_mistral_tests:
-                # action: core.remote
-                # input:
-                #     hosts: <% $.host_ip %>
-                #     env: <% $.st2_cli_env %>
-                #     cmd: cd /tmp/st2tests && source venv/bin/activate && pybot robotfm_tests/mistral/
-                #     timeout: 300
+                on-success:
+                    - robot_mistral_tests
+                robot_mistral_tests:
+                action: core.remote
+                input:
+                    hosts: <% $.host_ip %>
+                    env: <% $.st2_cli_env %>
+                    cmd: cd /tmp/st2tests && source venv/bin/activate && pybot robotfm_tests/mistral/
+                    timeout: 300
                 on-success:
                     - robot_chatopsCI_tests
             robot_chatopsCI_tests:


### PR DESCRIPTION
This just continues the great work started in https://github.com/StackStorm/st2cd/pull/243, and also enables robot testing for mistral