### PR TITLE
Fixing improper indentation in robot mistral tests

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -77,8 +77,7 @@ workflows:
                     cmd: cd /tmp/st2tests && . venv/bin/activate && pybot robotfm_tests/docs/
                     timeout: 500
                 on-success:
-                    - robot_mistral_tests
-            
+                    - robot_mistral_tests       
             robot_mistral_tests:
                 action: core.remote
                 input:

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -77,7 +77,7 @@ workflows:
                     cmd: cd /tmp/st2tests && . venv/bin/activate && pybot robotfm_tests/docs/
                     timeout: 500
                 on-success:
-                    - robot_mistral_tests       
+                    - robot_mistral_tests
             robot_mistral_tests:
                 action: core.remote
                 input:
@@ -87,7 +87,6 @@ workflows:
                     timeout: 300
                 on-success:
                     - robot_chatopsCI_tests
-
             robot_chatopsCI_tests:
                 action: core.remote
                 input:

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -80,14 +80,14 @@ workflows:
                     - robot_mistral_tests
             
             robot_mistral_tests:
-            action: core.remote
-            input:
-                hosts: <% $.host_ip %>
-                env: <% $.st2_cli_env %>
-                cmd: cd /tmp/st2tests && source venv/bin/activate && pybot robotfm_tests/mistral/
-                timeout: 300
-            on-success:
-                - robot_chatopsCI_tests
+                action: core.remote
+                input:
+                    hosts: <% $.host_ip %>
+                    env: <% $.st2_cli_env %>
+                    cmd: cd /tmp/st2tests && source venv/bin/activate && pybot robotfm_tests/mistral/
+                    timeout: 300
+                on-success:
+                    - robot_chatopsCI_tests
 
             robot_chatopsCI_tests:
                 action: core.remote

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -78,15 +78,17 @@ workflows:
                     timeout: 500
                 on-success:
                     - robot_mistral_tests
-                robot_mistral_tests:
-                action: core.remote
-                input:
-                    hosts: <% $.host_ip %>
-                    env: <% $.st2_cli_env %>
-                    cmd: cd /tmp/st2tests && source venv/bin/activate && pybot robotfm_tests/mistral/
-                    timeout: 300
-                on-success:
-                    - robot_chatopsCI_tests
+            
+            robot_mistral_tests:
+            action: core.remote
+            input:
+                hosts: <% $.host_ip %>
+                env: <% $.st2_cli_env %>
+                cmd: cd /tmp/st2tests && source venv/bin/activate && pybot robotfm_tests/mistral/
+                timeout: 300
+            on-success:
+                - robot_chatopsCI_tests
+
             robot_chatopsCI_tests:
                 action: core.remote
                 input:


### PR DESCRIPTION
https://github.com/StackStorm/st2cd/pull/246 made a typo and misplaced the indentation for this line. Simple fix for that.