### PR TITLE
Using www for google URLs

### DIFF
--- a/actions/workflows/e2e_tests.yaml
+++ b/actions/workflows/e2e_tests.yaml
@@ -65,19 +65,19 @@
         action: "core.local"
         params: "date"
         hosts: "{{hostname}}"
-      on-success: "core_http_github"
+      on-success: "core_http_google"
     -
-      name: "core_http_github"
+      name: "core_http_google"
       ref: "st2cd.action_run"
       params:
         env:
           ST2_BASE_URL: "{{protocol}}://{{hostname}}"
           ST2_AUTH_URL: "{{protocol}}://{{hostname}}:9100"
           ST2_API_URL: "{{protocol}}://{{hostname}}:9101"
-        name: "core_http_github"
+        name: "core_http_google"
         token: "{{st2_token}}"
         action: "core.http"
-        params: "url=https://github.com"
+        params: "url=https://www.google.com"
         hosts: "{{hostname}}"
       on-success: "core_remote_single_host"
     -

--- a/actions/workflows/e2e_tests.yaml
+++ b/actions/workflows/e2e_tests.yaml
@@ -65,19 +65,19 @@
         action: "core.local"
         params: "date"
         hosts: "{{hostname}}"
-      on-success: "core_http_google"
+      on-success: "core_http_github"
     -
-      name: "core_http_google"
+      name: "core_http_github"
       ref: "st2cd.action_run"
       params:
         env:
           ST2_BASE_URL: "{{protocol}}://{{hostname}}"
           ST2_AUTH_URL: "{{protocol}}://{{hostname}}:9100"
           ST2_API_URL: "{{protocol}}://{{hostname}}:9101"
-        name: "core_http_google"
+        name: "core_http_github"
         token: "{{st2_token}}"
         action: "core.http"
-        params: "url=https://www.google.com"
+        params: "url=https://github.com"
         hosts: "{{hostname}}"
       on-success: "core_remote_single_host"
     -

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -115,7 +115,7 @@ workflows:
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
-                    cmd: st2 run core.http url=https://github.com
+                    cmd: st2 run core.http url=https://www.google.com
             test_core_remote_single_host:
                 action: core.remote
                 input:

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -115,7 +115,7 @@ workflows:
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
-                    cmd: st2 run core.http url=https://google.com
+                    cmd: st2 run core.http url=https://github.com
             test_core_remote_single_host:
                 action: core.remote
                 input:


### PR DESCRIPTION
https://github.com/StackStorm/st2cd/pull/246 rewrote URLs to use google.com, but unfortunately this results in 301s, which the action treats as a failure.

Using www.google.com instead produces a successful code