### PR TITLE
Modified gitref sed statements to properly replace commented out vars

### DIFF
--- a/actions/st2_prep_release_for_st2_pkg.sh
+++ b/actions/st2_prep_release_for_st2_pkg.sh
@@ -101,8 +101,9 @@ fi
 # Update the st2 version at circle.yml
 CIRCLE_YML_FILE="circle.yml"
 echo "Setting version in ${CIRCLE_YML_FILE} to ${BRANCH}..."
-sed -i -e "s/\(ST2_GITREV:[ ]*\).*/\1${BRANCH}/" ${CIRCLE_YML_FILE}
-sed -i -e "s/\(ST2MISTRAL_GITREV:[ ]*\).*/\1${MISTRAL_VERSION}/" ${CIRCLE_YML_FILE}
+# capture group one is to ensure proper indentation. Capture group two is actual var definition
+sed -i -e "s/\(.*\)# \(ST2_GITREV:[ ]*\).*/\1\2${BRANCH}/" ${CIRCLE_YML_FILE}
+sed -i -e "s/\(.*\)# \(ST2MISTRAL_GITREV:[ ]*\).*/\1\2${MISTRAL_VERSION}/" ${CIRCLE_YML_FILE}
 
 MODIFIED=`git status | grep modified || true`
 if [[ ! -z "${MODIFIED}" ]]; then

--- a/actions/st2_prep_release_for_st2_pkg.sh
+++ b/actions/st2_prep_release_for_st2_pkg.sh
@@ -101,9 +101,9 @@ fi
 # Update the st2 version at circle.yml
 CIRCLE_YML_FILE="circle.yml"
 echo "Setting version in ${CIRCLE_YML_FILE} to ${BRANCH}..."
-# capture group one is to ensure proper indentation. Capture group two is actual var definition
-sed -i -e "s/\(.*\)# \(ST2_GITREV:[ ]*\).*/\1\2${BRANCH}/" ${CIRCLE_YML_FILE}
-sed -i -e "s/\(.*\)# \(ST2MISTRAL_GITREV:[ ]*\).*/\1\2${MISTRAL_VERSION}/" ${CIRCLE_YML_FILE}
+
+sed -i -e "s/#\s*\(ST2_GITREV:\s*\).*/\1${BRANCH}/" ${CIRCLE_YML_FILE}
+sed -i -e "s/#\s*\(ST2MISTRAL_GITREV:\s*\).*/\1${MISTRAL_VERSION}/" ${CIRCLE_YML_FILE}
 
 MODIFIED=`git status | grep modified || true`
 if [[ ! -z "${MODIFIED}" ]]; then


### PR DESCRIPTION
https://github.com/StackStorm/st2-packages/pull/428 adds commented-out definitions for ST2 and mistral gitrefs, so that at release time, these can be replaced with the right gitrefs.

This PR fixes the sed regular expression within the release prep scripts to take this into account.