### PR TITLE
Using period instead of 'source' keyword to set up env

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -83,7 +83,7 @@ workflows:
                 input:
                     hosts: <% $.host_ip %>
                     env: <% $.st2_cli_env %>
-                    cmd: cd /tmp/st2tests && source venv/bin/activate && pybot robotfm_tests/mistral/
+                    cmd: cd /tmp/st2tests && . venv/bin/activate && pybot robotfm_tests/mistral/
                     timeout: 300
                 on-success:
                     - robot_chatopsCI_tests


### PR DESCRIPTION
This was causing an error, because this command is running under /bin/sh, which doesn't have the "source" keyword. The dot notation should work across both `sh` and `bash`

> Other tests already use this notation, but we missed this when uncommenting this test in https://github.com/StackStorm/st2cd/pull/246, so this should rectify that