### PR TITLE
Add update function for mistral upgrade

### DIFF
--- a/actions/st2_perform_migrations.sh
+++ b/actions/st2_perform_migrations.sh
@@ -145,6 +145,14 @@ run_migration_scripts() {
     fi
   done
 }
+
+update_mistral_db() {
+  sudo service mistral-api stop
+  sudo service mistral stop
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+}
+
 ## Version specific migration functions. Note that the function names must have to
 ## migrate_to_${major}.${minor}. Otherwise, those methods won't be run.
 
@@ -153,17 +161,11 @@ migrate_to_1.5() {
   run_migration_scripts $scripts
 }
 
-migrate_to_2.2() {
-  sudo service mistral-api stop
-  sudo service mistral stop
-  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
-  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
-}
-
 trap 'fail' EXIT
 STEP="Setup args" && setup_args $@
 STEP="Validate versions" && validate_versions
 STEP="Perform migration" && perform_migration
+STEP="Perform updates" && update_mistral_db
 trap - EXIT
 
 ok_message

--- a/actions/st2_perform_migrations.sh
+++ b/actions/st2_perform_migrations.sh
@@ -153,6 +153,23 @@ migrate_to_1.5() {
   run_migration_scripts $scripts
 }
 
+migrate_to_2.2() {
+  sudo service mistral-api stop
+  sudo service mistral stop
+  sudo -u postgres psql
+  \connect mistral
+  DROP TABLE event_triggers_v2;
+  DROP TABLE workflow_executions_v2 CASCADE;
+  DROP TABLE task_executions_v2;
+  DROP TABLE action_executions_v2;
+  DROP TABLE named_locks;
+  \q
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+  sudo service mistral start
+  sudo service mistral-api start
+}
+
 trap 'fail' EXIT
 STEP="Setup args" && setup_args $@
 STEP="Validate versions" && validate_versions

--- a/actions/st2_perform_migrations.sh
+++ b/actions/st2_perform_migrations.sh
@@ -156,18 +156,8 @@ migrate_to_1.5() {
 migrate_to_2.2() {
   sudo service mistral-api stop
   sudo service mistral stop
-  sudo -u postgres psql
-  \connect mistral
-  DROP TABLE event_triggers_v2;
-  DROP TABLE workflow_executions_v2 CASCADE;
-  DROP TABLE task_executions_v2;
-  DROP TABLE action_executions_v2;
-  DROP TABLE named_locks;
-  \q
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
-  sudo service mistral start
-  sudo service mistral-api start
 }
 
 trap 'fail' EXIT


### PR DESCRIPTION
Several folks ran into [upgrade issues](https://gist.github.com/enykeev/c58ae6940f88a209e616410c726e002c#gistcomment-1997190) during manual testing and I am running into the same issues when doing automated upgrade testing as part of the release process (same error message):

    error: "(psycopg2.ProgrammingError) column "key" of relation "delayed_calls_v2" does not exist

The existing machinery does seem to perform the migration scripts, but a few `mistral-db-manage` commands need to be run (see [docs](https://docs.stackstorm.com/latest/install/upgrades.html?highlight=upgrades)). So this PR introduces a function to run these commands for each upgrade