### PR TITLE
Changed step to restart specific mistral services

### DIFF
--- a/actions/st2_perform_migrations.sh
+++ b/actions/st2_perform_migrations.sh
@@ -147,8 +147,7 @@ run_migration_scripts() {
 }
 
 update_mistral_db() {
-  sudo service mistral-api stop
-  sudo service mistral stop
+  $(sudo service stop mistral-api; sudo service stop mistral-server) || true
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
 }


### PR DESCRIPTION
https://github.com/StackStorm/st2cd/pull/251 implemented a function to perform mistral migrations when doing upgrade testing. However, because of the service dependency, this wouldn't work on all OSs.

This PR rewrites this instead to shut off the two specific mistral services, namely `mistral-server` and `mistral-api`, instead of the umbrella `mistral` service. It also does it on one line because that's how we roll.