### PR TITLE
Fixed syntax issue in mistral services stop

### DIFF
--- a/actions/st2_perform_migrations.sh
+++ b/actions/st2_perform_migrations.sh
@@ -147,7 +147,7 @@ run_migration_scripts() {
 }
 
 update_mistral_db() {
-  $(sudo service stop mistral-api; sudo service stop mistral-server) || true
+  $(sudo service mistral-api stop; sudo service mistral-server stop) || true
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
 }


### PR DESCRIPTION
Fairly self explanatory; https://github.com/StackStorm/st2cd/pull/252 rewrote the stop commands but swapped the commands. This PR swaps them back.