### PR TITLE
Various fixes for release finalization tasks

### DIFF
--- a/actions/st2_make_docs.meta.yaml
+++ b/actions/st2_make_docs.meta.yaml
@@ -42,4 +42,4 @@ parameters:
         immutable: true
         default: "--"
     timeout:
-        default: 900
+        default: 1800

--- a/actions/st2_prep_release_rules.meta.yaml
+++ b/actions/st2_prep_release_rules.meta.yaml
@@ -16,10 +16,6 @@ parameters:
         required: true
     oses:
         type: string
-        description: "Space seperated list of operating systems supported by st2 e.g. 'rhel6 rhel7 u14 u16'"
+        description: "Space separated list of operating systems supported by st2 e.g. 'rhel6 rhel7 u14 u16'"
         required: true
         default: rhel6 rhel7 u14 u16
-    local_repo:
-        type: string
-        description: Location where to clone the repo. Programmatically determined if not provided.
-        position: 4

--- a/actions/workflows/bwc_finalize_release.yaml
+++ b/actions/workflows/bwc_finalize_release.yaml
@@ -50,17 +50,17 @@ st2cd.bwc_finalize_release:
                 - make_bwc_docs_latest
         make_bwc_docs_latest:
             action: st2cd.bwc_docs
-            on-success:
-                - push_bwc_client
-        push_bwc_client:
-            action: st2cd.pypi_upload
-            input:
-                repo: bwc-cli
-                version: <% $.version %>
-                fork: <% $.fork %>
-                local_repo: <% 'bwc_cli_' + $.local_repo_sfx %>
-                hosts: <% $.host %>
-                cwd: <% $.cwd %>
+        #     on-success:
+        #         - push_bwc_client
+        # push_bwc_client:
+        #     action: st2cd.pypi_upload
+        #     input:
+        #         repo: bwc-cli
+        #         version: <% $.version %>
+        #         fork: <% $.fork %>
+        #         local_repo: <% 'bwc_cli_' + $.local_repo_sfx %>
+        #         hosts: <% $.host %>
+        #         cwd: <% $.cwd %>
 
 
         cleanup_on_failure:

--- a/actions/workflows/st2_prep_release_rules.yaml
+++ b/actions/workflows/st2_prep_release_rules.yaml
@@ -4,8 +4,7 @@ st2cd.st2_prep_release_rules:
     input:
         - version
         - prev_version
-        - host
-        - cwd
+        - oses
 
     vars:
         local_repo_sfx: null
@@ -21,9 +20,8 @@ st2cd.st2_prep_release_rules:
                 cmd: "echo `date +'%s'`_`awk -v min=100 -v max=999 'BEGIN{srand(); print int(min+rand()*(max-min+1))}'`"
             publish:
                 local_repo_sfx: <% task(init).result.stdout %>
-            on-success:
-                - get_host: <% $.host = null %>
-                - prep: <% $.host != null %>
+            on-complete:
+                - get_host
 
 
         get_host:
@@ -45,25 +43,21 @@ st2cd.st2_prep_release_rules:
             action: st2cd.st2_prep_release_ci_rules
             input:
                 project: st2ci
-                fork: <% $.fork %>
                 version: <% $.version %>
                 prev_version: <% $.prev_version %>
                 local_repo: <% 'st2ci' + $.local_repo_sfx %>
                 hosts: <% $.host %>
-                cwd: <% $.cwd %>
             on-success:
                 - prep_cd_rules
         prep_cd_rules:
             action: st2cd.st2_prep_release_cd_rules
             input:
                 project: st2cd
-                fork: <% $.fork %>
                 version: <% $.version %>
                 prev_version: <% $.prev_version %>
                 oses: <% $.oses %>
                 local_repo: <% 'st2cd' + $.local_repo_sfx %>
                 hosts: <% $.host %>
-                cwd: <% $.cwd %>
 
         cleanup_on_failure:
             action: core.remote


### PR DESCRIPTION
This addresses a few issues that came up in this repo at the tail end of the 2.2 release.

- Increase timeout for docs build - 900 just wasn't long enough this release
- Disabled the task that uploads `bwc-cli` to pypi at @lakshmi-kannan request - as that's done in a separate process now
- Spent a chunk of time grokking what was implemented in https://github.com/StackStorm/st2cd/pull/239 - found a few errors and tried to fix them as simply as possible while preserving the original intention of the PR. I managed to get it working so that https://github.com/StackStorm/st2cd/commit/c075eff73a040e2642bbcca14046298d78c99445 and https://github.com/StackStorm/st2ci/commit/672069d0fc7c87552eb42e1de8ab464f738154f0 were created automatically because of these scripts (well done @bigmstone, those shell scripts worked like a dream). This includes removing `fork` as this variable wasn't defined anywhere, so omitting it will result in the underlying action defaulting to `StackStorm` (this can obviously be fully implemented in a future PR if needed) as well as removing `cwd` as that was not mentioned in the workflow metadata, and defaulting to `/tmp` is fine for this use case as well.

Please note that I opened the following issues to make sure I captured what I was seeing as "strange behavior", in case they're bugs:

- https://github.com/StackStorm/st2cd/issues/254
- https://github.com/StackStorm/st2/issues/3252
