### PR TITLE
Fix rule name

### DIFF
--- a/rules/st2_docs_v22.yaml
+++ b/rules/st2_docs_v22.yaml
@@ -1,5 +1,5 @@
 ---
-    name: "st2_docs_v21"
+    name: "st2_docs_v22"
     pack: "st2cd"
     description: "Build st2 docs for StackStorm v2.2"
     enabled: true


### PR DESCRIPTION
Notice rule was not present on the server while checking why the docs builds are not triggered.