### PR TITLE
Adding action to update bootstrap script with new version

### DIFF
--- a/actions/st2_update_bootstrap.meta.yaml
+++ b/actions/st2_update_bootstrap.meta.yaml
@@ -1,0 +1,25 @@
+---
+name: st2_update_bootstrap
+description: Update bootstrap script with new release version
+enabled: true
+runner_type: remote-shell-script
+entry_point: st2_update_bootstrap.sh
+parameters:
+    local_repo:
+        type: string
+        description: Location where to clone the repo. Programmatically determined if not provided.
+        position: 1
+    dir:
+        immutable: true
+        default: /home/stanley/
+    sudo:
+        immutable: true
+        default: false
+    cmd:
+        immutable: true
+        default: ""
+    kwarg_op:
+        immutable: true
+        default: "--"
+    timeout:
+        default: 900

--- a/actions/st2_update_bootstrap.sh
+++ b/actions/st2_update_bootstrap.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+PROJECT="st2-packages"
+BRANCH="master"
+FORK="StackStorm"
+LOCAL_REPO=$1
+GIT_REPO="git@github.com:${FORK}/${PROJECT}.git"
+CWD=`pwd`
+
+
+# CHECK IF BRANCH EXISTS
+BRANCH_EXISTS=`git ls-remote --heads ${GIT_REPO} | grep refs/heads/${BRANCH} || true`
+
+if [[ -z "${BRANCH_EXISTS}" ]]; then
+    >&2 echo "ERROR: Branch ${BRANCH} doesn't exist in ${GIT_REPO}."
+    exit 1
+fi
+
+
+# GIT CLONE AND BRANCH
+if [[ -z ${LOCAL_REPO} ]]; then
+    CURRENT_TIMESTAMP=`date +'%s'`
+    RANDOM_NUMBER=`awk -v min=100 -v max=999 'BEGIN{srand(); print int(min+rand()*(max-min+1))}'`
+    LOCAL_REPO=${PROJECT}_${CURRENT_TIMESTAMP}_${RANDOM_NUMBER}
+fi
+
+echo "Cloning ${GIT_REPO} to ${LOCAL_REPO}..."
+
+if [ -d "${LOCAL_REPO}" ]; then
+    rm -rf ${LOCAL_REPO}
+fi
+
+git clone ${GIT_REPO} ${LOCAL_REPO}
+
+cd ${LOCAL_REPO}
+echo "Currently at directory `pwd`..."
+
+# CHECKOUT BRANCH
+if [ "${BRANCH}" != "master" ]; then
+    echo "Checking out branch ${BRANCH}..."
+    git checkout -b ${BRANCH} origin/${BRANCH}
+fi
+
+# Replace BRANCH that uses single-quotes with new version
+sed -i "s/BRANCH='.*/BRANCH='${VERSION}'/g" ./scripts/st2_bootstrap.sh
+
+git add ./scripts
+git commit -m "Updating bootstrap script with $VERSION release"
+git push
+
+
+# CLEANUP
+cd ${CWD}
+rm -rf ${LOCAL_REPO}

--- a/actions/st2_update_bootstrap.sh
+++ b/actions/st2_update_bootstrap.sh
@@ -43,7 +43,7 @@ if [ "${BRANCH}" != "master" ]; then
 fi
 
 # Replace BRANCH that uses single-quotes with new version
-sed -i "s/BRANCH='.*/BRANCH='${VERSION}'/g" ./scripts/st2_bootstrap.sh
+sed -i "s/BRANCH=.*${PREVIOUS_VERSION}.*/BRANCH='${VERSION}'/g" ./scripts/st2_bootstrap.sh
 
 git add ./scripts
 git commit -m "Updating bootstrap script with $VERSION release"

--- a/actions/st2_update_bootstrap.sh
+++ b/actions/st2_update_bootstrap.sh
@@ -42,7 +42,7 @@ if [ "${BRANCH}" != "master" ]; then
     git checkout -b ${BRANCH} origin/${BRANCH}
 fi
 
-# Replace BRANCH that uses single-quotes with new version
+# Replace BRANCH that currently references old version
 sed -i "s/BRANCH=.*${PREVIOUS_VERSION}.*/BRANCH='${VERSION}'/g" ./scripts/st2_bootstrap.sh
 
 git add ./scripts

--- a/actions/workflows/st2_finalize_release.yaml
+++ b/actions/workflows/st2_finalize_release.yaml
@@ -111,7 +111,14 @@ st2cd.st2_finalize_release:
                 local_repo: <% 'st2_' + $.local_repo_sfx %>
                 hosts: <% $.host %>
                 cwd: <% $.cwd %>
-
+            on-success:
+                - st2_update_bootstrap
+        st2_update_bootstrap:
+            action: st2cd.st2_update_bootstrap
+            input:
+                local_repo: <% 'st2_' + $.local_repo_sfx %>
+                hosts: <% $.host %>
+                cwd: <% $.cwd %>
 
         cleanup_on_failure:
             action: core.remote


### PR DESCRIPTION
This PR introduces a new action to replace the branch version being used in the bootstrap script (in st2-packages).

Currently, that line uses single quotes, and so I am just looking for `BRANCH='.*` in my sed regex. Since BRANCH is defined elsewhere, but only here with single quotes, I figured that was useful and perhaps intended. Let me know if this is too fragile and I'll come up with something else.