### PR TITLE
Update st2_e2e_tests action to also run run new st2tests tests for st2-run-pack-tests

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -235,6 +235,15 @@ workflows:
                     cmd: st2 run tests.test_quickstart_trace <% $.st2_cli_args %>
                     timeout: 600
                 on-success:
+                    - test_quickstart_run_pack_tests_tool
+            test_quickstart_run_pack_tests_tool:
+                action: core.remote
+                input:
+                    hosts: <% $.host %>
+                    env: <% $.env %>
+                    cmd: st2 run tests.test_run_pack_tests_tool <% $.st2_cli_args %>
+                    timeout: 600
+                on-success:
                     - test_quickstart_timer_rules
             test_quickstart_timer_rules:
                 action: core.remote


### PR DESCRIPTION
This pull request updates existing `st2_e2e_tests` workflow to also run new st2tests for `st2-run-pack-tests` command (https://github.com/StackStorm/st2tests/pull/100).