### PR TITLE
Don't run st2-run-pack-tests tests if they are not available

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -242,7 +242,7 @@ workflows:
                     hosts: <% $.host %>
                     env: <% $.env %>
                     # Note: This test is only available and working in StackStorm >= 2.3dev
-                    cmd: "st2 action get tests.test_run_pack_tests_tool && st2 run tests.test_run_pack_tests_tool <% $.st2_cli_args %> || echo 'run_pack_tests_tool tests not available'"
+                    cmd: "st2 action get tests.test_windows_runners ; if [ $? -eq 0 ]; then st2 run tests.test_run_pack_tests_tool <% $.st2_cli_args %>; else 'run_pack_tests_tool tests not available'; fi"
                     timeout: 600
                 on-success:
                     - test_quickstart_timer_rules

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -242,7 +242,7 @@ workflows:
                     hosts: <% $.host %>
                     env: <% $.env %>
                     # Note: This test is only available and working in StackStorm >= 2.3dev
-                    cmd: "st2 action get tests.test_run_pack_tests_tool ; if [ $? -eq 0 ]; then st2 run tests.test_run_pack_tests_tool <% $.st2_cli_args %>; else 'run_pack_tests_tool tests not available'; fi"
+                    cmd: "st2 action get tests.test_run_pack_tests_tool ; if [ $? -eq 0 ]; then st2 run tests.test_run_pack_tests_tool <% $.st2_cli_args %>; else echo 'run_pack_tests_tool tests not available'; fi"
                     timeout: 600
                 on-success:
                     - test_quickstart_timer_rules

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -242,7 +242,7 @@ workflows:
                     hosts: <% $.host %>
                     env: <% $.env %>
                     # Note: This test is only available and working in StackStorm >= 2.3dev
-                    cmd: "st2 action get tests.test_windows_runners ; if [ $? -eq 0 ]; then st2 run tests.test_run_pack_tests_tool <% $.st2_cli_args %>; else 'run_pack_tests_tool tests not available'; fi"
+                    cmd: "st2 action get tests.test_run_pack_tests_tool ; if [ $? -eq 0 ]; then st2 run tests.test_run_pack_tests_tool <% $.st2_cli_args %>; else 'run_pack_tests_tool tests not available'; fi"
                     timeout: 600
                 on-success:
                     - test_quickstart_timer_rules

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -241,7 +241,8 @@ workflows:
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
-                    cmd: st2 run tests.test_run_pack_tests_tool <% $.st2_cli_args %>
+                    # Note: This test is only available and working in StackStorm >= 2.3dev
+                    cmd: "st2 action get tests.test_run_pack_tests_tool && st2 run tests.test_run_pack_tests_tool <% $.st2_cli_args %> || echo 'run_pack_tests_tool tests not available'"
                     timeout: 600
                 on-success:
                     - test_quickstart_timer_rules


### PR DESCRIPTION
Those tests are only available and applicable to StackStorm >= v2.3dev so they shouldn't run if the tests are not available (e.g. when running tests against an older version branch such as v2.1 or v2.2).

Eventually, we should probably refactor the work-code and move this inside a script is located inside in st2tests repo or similar. This way we don't need to do those checks inside the workflows and the whole thing is more robust.