### PR TITLE
Manually update rules to catch up to current release

### DIFF
--- a/rules/st2_pkg_test_stable_rhel6.yaml
+++ b/rules/st2_pkg_test_stable_rhel6.yaml
@@ -21,4 +21,4 @@ action:
     distro: RHEL6
     pkg_env: production
     release: stable
-    version: "2.1.0"
+    version: "2.2.0"

--- a/rules/st2_pkg_test_stable_rhel6_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_rhel6_enterprise.yaml
@@ -21,6 +21,6 @@ action:
     distro: RHEL6
     pkg_env: production
     release: stable
-    version: "2.1.0"
+    version: "2.2.0"
     enterprise: true
     enterprise_key: "{{system.enterprise_key_prd_stable}}"

--- a/rules/st2_pkg_test_stable_rhel7.yaml
+++ b/rules/st2_pkg_test_stable_rhel7.yaml
@@ -21,4 +21,4 @@ action:
     distro: RHEL7
     pkg_env: production
     release: stable
-    version: "2.1.0"
+    version: "2.2.0"

--- a/rules/st2_pkg_test_stable_rhel7_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_rhel7_enterprise.yaml
@@ -21,6 +21,6 @@ action:
     distro: RHEL7
     pkg_env: production
     release: stable
-    version: "2.1.0"
+    version: "2.2.0"
     enterprise: true
     enterprise_key: "{{system.enterprise_key_prd_stable}}"

--- a/rules/st2_pkg_test_stable_u14.yaml
+++ b/rules/st2_pkg_test_stable_u14.yaml
@@ -21,4 +21,4 @@ action:
     distro: UBUNTU14
     pkg_env: production
     release: stable
-    version: "2.1.0"
+    version: "2.2.0"

--- a/rules/st2_pkg_test_stable_u14_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_u14_enterprise.yaml
@@ -21,6 +21,6 @@ action:
     distro: UBUNTU14
     pkg_env: production
     release: stable
-    version: "2.1.0"
+    version: "2.2.0"
     enterprise: true
     enterprise_key: "{{system.enterprise_key_prd_stable}}"

--- a/rules/st2_pkg_test_stable_u16.yaml
+++ b/rules/st2_pkg_test_stable_u16.yaml
@@ -21,4 +21,4 @@ action:
     distro: UBUNTU16
     pkg_env: production
     release: stable
-    version: "2.1.0"
+    version: "2.2.0"

--- a/rules/st2_pkg_test_stable_u16_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_u16_enterprise.yaml
@@ -21,6 +21,6 @@ action:
     distro: UBUNTU16
     pkg_env: production
     release: stable
-    version: "2.1.0"
+    version: "2.2.0"
     enterprise: true
     enterprise_key: "{{system.enterprise_key_prd_stable}}"


### PR DESCRIPTION
The current version in the daily e2e testing rules is out of date, since there's currently no automated process to take care of this during release, and no manual update step is listed in the wiki.

I'll be submitting a PR soon to satisfy https://github.com/StackStorm/st2cd/issues/263, and add automated update steps for future releases, but in order for that to work, the versions as they currently exist needs to be updated to the release that's out as of now, which this PR accomplishes.

**Remember to do a fresh `git pull` and `st2ctl reload` once this is merged, and ensure the new rules are operating**

EDIT: There actually is an automated process, as @bigmstone implemented in https://github.com/StackStorm/st2cd/pull/239. However, it looks like the release immediately following the implementation of that PR either didn't work, or perhaps used the wrong "previous" version, since the script requires a correct previous version in order for the sed replace to work. So, #263 might not be necessary. I'll update there.