### PR TITLE
Skip rule creation if already exists

### DIFF
--- a/actions/st2_prep_release_cd_rules.sh
+++ b/actions/st2_prep_release_cd_rules.sh
@@ -54,7 +54,7 @@ function create_new_rules {
         cat ./rules/bwc_docs_ipfabric_prod_$PREV_FILE_POSTFIX_UNDERSCORE.yaml > ./rules/bwc_docs_ipfabric_prod_$FILE_POSTFIX_UNDERSCORE.yaml
         cat ./rules/st2_docs_$PREV_FILE_POSTFIX.yaml > ./rules/st2_docs_$FILE_POSTFIX.yaml
         cat ./rules/bwc_docs_prod_$PREV_FILE_POSTFIX_UNDERSCORE.yaml > ./rules/bwc_docs_prod_$FILE_POSTFIX_UNDERSCORE.yaml
-    elif
+    fi
 }
 
 function update_new_rules {

--- a/actions/st2_prep_release_cd_rules.sh
+++ b/actions/st2_prep_release_cd_rules.sh
@@ -47,10 +47,14 @@ function git_repo {
 }
 
 function create_new_rules {
-    # Ignoring "file already exists" error (this will happen for patch releases, since minor release created this file already)
-    cat ./rules/bwc_docs_ipfabric_prod_$PREV_FILE_POSTFIX_UNDERSCORE.yaml > ./rules/bwc_docs_ipfabric_prod_$FILE_POSTFIX_UNDERSCORE.yaml || true
-    cat ./rules/st2_docs_$PREV_FILE_POSTFIX.yaml > ./rules/st2_docs_$FILE_POSTFIX.yaml || true
-    cat ./rules/bwc_docs_prod_$PREV_FILE_POSTFIX_UNDERSCORE.yaml > ./rules/bwc_docs_prod_$FILE_POSTFIX_UNDERSCORE.yaml  || true
+    # Skip if the two intended versions are the same.
+    # This can happen on patch releases, since 2.2.1 is reduced to v2.2, which is the same as if the version was 2.2.0
+    if [ "$PREV_FILE_POSTFIX_UNDERSCORE" != "$FILE_POSTFIX_UNDERSCORE" ]
+    then
+        cat ./rules/bwc_docs_ipfabric_prod_$PREV_FILE_POSTFIX_UNDERSCORE.yaml > ./rules/bwc_docs_ipfabric_prod_$FILE_POSTFIX_UNDERSCORE.yaml
+        cat ./rules/st2_docs_$PREV_FILE_POSTFIX.yaml > ./rules/st2_docs_$FILE_POSTFIX.yaml
+        cat ./rules/bwc_docs_prod_$PREV_FILE_POSTFIX_UNDERSCORE.yaml > ./rules/bwc_docs_prod_$FILE_POSTFIX_UNDERSCORE.yaml
+    elif
 }
 
 function update_new_rules {

--- a/actions/st2_prep_release_cd_rules.sh
+++ b/actions/st2_prep_release_cd_rules.sh
@@ -47,9 +47,10 @@ function git_repo {
 }
 
 function create_new_rules {
-    cat ./rules/bwc_docs_ipfabric_prod_$PREV_FILE_POSTFIX_UNDERSCORE.yaml > ./rules/bwc_docs_ipfabric_prod_$FILE_POSTFIX_UNDERSCORE.yaml
-    cat ./rules/st2_docs_$PREV_FILE_POSTFIX.yaml > ./rules/st2_docs_$FILE_POSTFIX.yaml
-    cat ./rules/bwc_docs_prod_$PREV_FILE_POSTFIX_UNDERSCORE.yaml > ./rules/bwc_docs_prod_$FILE_POSTFIX_UNDERSCORE.yaml
+    # Ignoring "file already exists" error (this will happen for patch releases, since minor release created this file already)
+    cat ./rules/bwc_docs_ipfabric_prod_$PREV_FILE_POSTFIX_UNDERSCORE.yaml > ./rules/bwc_docs_ipfabric_prod_$FILE_POSTFIX_UNDERSCORE.yaml || true
+    cat ./rules/st2_docs_$PREV_FILE_POSTFIX.yaml > ./rules/st2_docs_$FILE_POSTFIX.yaml || true
+    cat ./rules/bwc_docs_prod_$PREV_FILE_POSTFIX_UNDERSCORE.yaml > ./rules/bwc_docs_prod_$FILE_POSTFIX_UNDERSCORE.yaml  || true
 }
 
 function update_new_rules {

--- a/actions/st2_prep_release_ci_rules.sh
+++ b/actions/st2_prep_release_ci_rules.sh
@@ -40,7 +40,8 @@ function git_repo {
 }
 
 function create_new_rules {
-    cat ./rules/st2_pkg_build_${PREV_FILE_POSTFIX_UNDERSCORE}_on_pytest.yaml > ./rules/st2_pkg_build_${FILE_POSTFIX_UNDERSCORE}_on_pytest.yaml
+    # Ignoring "file already exists" error (this will happen for patch releases, since minor release created this file already)
+    cat ./rules/st2_pkg_build_${PREV_FILE_POSTFIX_UNDERSCORE}_on_pytest.yaml > ./rules/st2_pkg_build_${FILE_POSTFIX_UNDERSCORE}_on_pytest.yaml || true
 }
 
 function update_new_rules {

--- a/actions/st2_prep_release_ci_rules.sh
+++ b/actions/st2_prep_release_ci_rules.sh
@@ -45,7 +45,7 @@ function create_new_rules {
     if [ "$PREV_FILE_POSTFIX_UNDERSCORE" != "$FILE_POSTFIX_UNDERSCORE" ]
     then
         cat ./rules/st2_pkg_build_${PREV_FILE_POSTFIX_UNDERSCORE}_on_pytest.yaml > ./rules/st2_pkg_build_${FILE_POSTFIX_UNDERSCORE}_on_pytest.yaml
-    elif
+    fi
 }
 
 function update_new_rules {

--- a/actions/st2_prep_release_ci_rules.sh
+++ b/actions/st2_prep_release_ci_rules.sh
@@ -40,8 +40,12 @@ function git_repo {
 }
 
 function create_new_rules {
-    # Ignoring "file already exists" error (this will happen for patch releases, since minor release created this file already)
-    cat ./rules/st2_pkg_build_${PREV_FILE_POSTFIX_UNDERSCORE}_on_pytest.yaml > ./rules/st2_pkg_build_${FILE_POSTFIX_UNDERSCORE}_on_pytest.yaml || true
+    # Skip if the two intended versions are the same.
+    # This can happen on patch releases, since 2.2.1 is reduced to v2.2, which is the same as if the version was 2.2.0
+    if [ "$PREV_FILE_POSTFIX_UNDERSCORE" != "$FILE_POSTFIX_UNDERSCORE" ]
+    then
+        cat ./rules/st2_pkg_build_${PREV_FILE_POSTFIX_UNDERSCORE}_on_pytest.yaml > ./rules/st2_pkg_build_${FILE_POSTFIX_UNDERSCORE}_on_pytest.yaml
+    elif
 }
 
 function update_new_rules {


### PR DESCRIPTION
As explained in https://github.com/StackStorm/st2cd/issues/271, the rule creation step at the end of the patch release was failing because `cat` was throwing an error when the destination file and source file were the same, which will happen for patch releases. This prevented the latter portion of the workflow from running, which updates the st2cd rules to use the new version, which includes patch.

So this PR simply skips the rule creation when these two versions are identical.

Closes https://github.com/StackStorm/st2cd/issues/271