### PR TITLE
Ignore errors on empty commits

### DIFF
--- a/actions/st2_prep_release_cd_rules.sh
+++ b/actions/st2_prep_release_cd_rules.sh
@@ -76,7 +76,7 @@ function update_existing_rules {
 
 function git_finish {
     git add ./rules
-    git commit -m "Adding/Updating rules for $VERSION release"
+    git commit -m "Adding/Updating rules for $VERSION release" || true
     git push
 }
 

--- a/actions/st2_prep_release_ci_rules.sh
+++ b/actions/st2_prep_release_ci_rules.sh
@@ -54,7 +54,7 @@ function update_new_rules {
 
 function git_finish {
     git add ./rules
-    git commit -m "Adding/Updating rules for $VERSION release"
+    git commit -m "Adding/Updating rules for $VERSION release" || true
     git push
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/StackStorm/st2cd/pull/272 - as a result of that change, sometimes no changes will be made, so `git commit` will choke on this.