### PR TITLE
Bump setup_e2e_tests task timeout

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -45,7 +45,7 @@ workflows:
                     hosts: <% $.host_ip %>
                     env: <% $.st2_cli_env %>
                     version: <% $.version %>
-                    timeout: 180
+                    timeout: 220
                 on-success:
                     - run_basic_tests
             run_basic_tests:


### PR DESCRIPTION
A while ago we made a change to `st2ctl` so it correctly waits on the services to start (or fail to start).

This means that the whole `st2ctl restart`, etc. command can now take much longer to finish and complete and that's why I increased the task timeout.