### PR TITLE
Update linux.scp action parameters

### DIFF
--- a/actions/workflows/st2_flow_deploy.yaml
+++ b/actions/workflows/st2_flow_deploy.yaml
@@ -24,8 +24,7 @@
         hosts: "st2build001"
         source: "/tmp/{{hostname}}-flow.tar.gz"
         keyfile: "/home/stanley/.ssh/st2_stanley_key"
-        dest_server: "{{hostname}}"
-        destination: "/tmp/"
+        destination: "{{hostname}}:/tmp/"
       on-success: "clean_flow"
     -
       name: "clean_flow"


### PR DESCRIPTION
Change for backward-incompatible change in https://github.com/StackStorm/st2/pull/3335/.

We need to merge that before / after st2 PR is merged otherwise build will break.