### PR TITLE
Fix branch in st2-packages 'scripts/st2_bootstrap.sh'

### DIFF
--- a/actions/st2_prep_release_for_st2_pkg.sh
+++ b/actions/st2_prep_release_for_st2_pkg.sh
@@ -71,6 +71,12 @@ if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
     fi
 fi
 
+# 'scripts/st2_bootstrap.sh'
+# Pin bash installer to latest stable 'st2-packages' branch in 'master'
+# Replace only the first occurrence!
+sed "0,/BRANCH=.*/ s//BRANCH='${BRANCH}'/" scripts/st2_bootstrap.sh
+
+
 MODIFIED=`git status | grep modified || true`
 if [[ ! -z "${MODIFIED}" ]]; then
     git add ${VERSION_FILE}


### PR DESCRIPTION
> Closes https://github.com/StackStorm/st2cd/pull/260

Fix for `st2_prep_release_for_st2_pkg` action to pin the version in st2-packages `curl|bash` installer `scripts/st2_bootstrap.sh`

Example change: https://github.com/StackStorm/st2-packages/commit/eee3cfb69f6717d902510005a16c0f6425c49d3f

