### PR TITLE
Fixes for st2-packages 'scripts/st2_bootstrap.sh' 'rake/build/environment.rb'

### DIFF
--- a/actions/st2_prep_release_for_st2_pkg.sh
+++ b/actions/st2_prep_release_for_st2_pkg.sh
@@ -64,7 +64,7 @@ fi
 # Replace only the first occurrence!
 VERSION_FILE="scripts/st2_bootstrap.sh"
 echo "[master] Setting version in ${VERSION_FILE} to ${BRANCH}..."
-sed "0,/BRANCH=.*/ s//BRANCH='${BRANCH}'/" ${VERSION_FILE}
+sed -i -e "0,/BRANCH=.*/ s//BRANCH='${BRANCH}'/" ${VERSION_FILE}
 
 
 MODIFIED=`git status | grep modified || true`

--- a/actions/st2_prep_release_for_st2_pkg.sh
+++ b/actions/st2_prep_release_for_st2_pkg.sh
@@ -7,6 +7,7 @@ FORK=$3
 LOCAL_REPO=$4
 GIT_REPO="git@github.com:${FORK}/${PROJECT}.git"
 SHORT_VERSION=`echo ${VERSION} | cut -d "." -f1-2`
+DEV_VERSION="$(sed "s/\(.\)\(.\)/\1.\2/" <<< "$((${SHORT_VERSION//.}+1))")dev"
 MISTRAL_VERSION="st2-${VERSION}"
 BRANCH="v${SHORT_VERSION}"
 CWD=`pwd`
@@ -40,33 +41,21 @@ cd ${LOCAL_REPO}
 echo "Currently at directory `pwd`..."
 
 
-# SET NEW MISTRAL VERSION INFO AT MASTER
+####################################
+# MASTER
+####################################
+
+# Update mistral 'mistral_version' to latest dev "X.Ydev" at 'rake/build/environment.rb'
 VERSION_FILE="rake/build/environment.rb"
-
-# Update the mistral version (1st location)
-NEW_MISTRAL_VERSION_STR="envpass :gitrev,[ ]*'${MISTRAL_VERSION}',[ ]*from: 'ST2MISTRAL_GITREV'"
+NEW_MISTRAL_VERSION_STR="envpass :mistral_version, '${DEV_VERSION}'"
 NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
 if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
-    echo "[master] Setting mistral version (1st location) in ${VERSION_FILE} to ${MISTRAL_VERSION}..."
-    sed -i -e "s/\(envpass :gitrev,[ ]*'\).*\(',[ ]*from: 'ST2MISTRAL_GITREV'\)/\1${MISTRAL_VERSION}\2/" ${VERSION_FILE}
+    echo "[master] Setting 'mistral_version' in '${VERSION_FILE}' to latest dev: '${DEV_VERSION}'..."
+    sed -i -e "s/\(envpass :mistral_version, \).*/\1'${DEV_VERSION}'/" ${VERSION_FILE}
 
     NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
     if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
-        >&2 echo "[master] ERROR: Unable to update the mistral version (1st location) in ${VERSION_FILE}."
-        exit 1
-    fi
-fi
-
-# Update the mistral version (2nd location)
-NEW_MISTRAL_VERSION_STR="envpass :mistral_version, '${VERSION}'"
-NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
-if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
-    echo "[master] Setting mistral version (2nd location) in ${VERSION_FILE} to ${MISTRAL_VERSION}..."
-    sed -i -e "s/\(envpass :mistral_version, \).*/\1'${VERSION}'/" ${VERSION_FILE}
-
-    NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
-    if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
-        >&2 echo "[master] ERROR: Unable to update the mistral version (2nd location) in ${VERSION_FILE}."
+        >&2 echo "[master] ERROR: Unable to update the 'mistral_version' to latest dev in '${VERSION_FILE}'."
         exit 1
     fi
 fi
@@ -85,25 +74,59 @@ if [[ ! -z "${MODIFIED}" ]]; then
     git push origin master -q
 fi
 
-
+####################################
+# NEW BRANCH
+####################################
 # CREATE RELEASE BRANCH AND SET NEW ST2 VERSION INFO
 echo "Creating new branch ${BRANCH}..."
 git checkout -b ${BRANCH} origin/master
 
-# Update the st2 version at rake/build/environment.rb
+
+# Update st2 'ST2_GITREV' to latest stable 'vX.Y' branch at 'rake/build/environment.rb'
 VERSION_FILE="rake/build/environment.rb"
 NEW_VERSION_STR="envpass :gitrev,[ ]*'${BRANCH}',[ ]*from: 'ST2_GITREV'"
 NEW_VERSION_STR_MATCH=`grep "${NEW_VERSION_STR}" ${VERSION_FILE} || true`
 if [[ -z "${NEW_VERSION_STR_MATCH}" ]]; then
-    echo "[${BRANCH}] Setting version in ${VERSION_FILE} to ${BRANCH}..."
+    echo "[${BRANCH}] Setting version in '${VERSION_FILE}' to '${BRANCH}'..."
     sed -i -e "s/\(envpass :gitrev,[ ]*'\).*\(',[ ]*from: 'ST2_GITREV'\)/\1${BRANCH}\2/" ${VERSION_FILE}
 
     NEW_VERSION_STR_MATCH=`grep "${NEW_VERSION_STR}" ${VERSION_FILE} || true`
     if [[ -z "${NEW_VERSION_STR_MATCH}" ]]; then
-        >&2 echo "[${BRANCH}] ERROR: Unable to update the st2 version in ${VERSION_FILE}."
+        >&2 echo "[${BRANCH}] ERROR: Unable to update the st2 version in '${VERSION_FILE}'."
         exit 1
     fi
 fi
+
+# Update mistral 'ST2MISTRAL_GITREV' branch to latest stable 'st2-X.Y' at 'rake/build/environment.rb'
+VERSION_FILE="rake/build/environment.rb"
+NEW_MISTRAL_VERSION_STR="envpass :gitrev,[ ]*'${MISTRAL_VERSION}',[ ]*from: 'ST2MISTRAL_GITREV'"
+NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
+if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
+    echo "[master] Setting 'ST2MISTRAL_GITREV' branch in '${VERSION_FILE}' to latest stable '${MISTRAL_VERSION}'..."
+    sed -i -e "s/\(envpass :gitrev,[ ]*'\).*\(',[ ]*from: 'ST2MISTRAL_GITREV'\)/\1${MISTRAL_VERSION}\2/" ${VERSION_FILE}
+
+    NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
+    if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
+        >&2 echo "[master] ERROR: Unable to update the 'ST2MISTRAL_GITREV' in '${VERSION_FILE}'."
+        exit 1
+    fi
+fi
+
+# Update mistral 'mistral_version' to latest stable 'X.Y' version at 'rake/build/environment.rb'
+VERSION_FILE="rake/build/environment.rb"
+NEW_MISTRAL_VERSION_STR="envpass :mistral_version, '${VERSION}'"
+NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
+if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
+    echo "[master] Setting 'mistral_version' in '${VERSION_FILE}' to latest stable '${VERSION}'..."
+    sed -i -e "s/\(envpass :mistral_version, \).*/\1'${VERSION}'/" ${VERSION_FILE}
+
+    NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
+    if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
+        >&2 echo "[master] ERROR: Unable to update the 'mistral_version' in '${VERSION_FILE}'."
+        exit 1
+    fi
+fi
+
 
 # Update the st2 version at circle.yml
 CIRCLE_YML_FILE="circle.yml"

--- a/actions/st2_prep_release_for_st2_pkg.sh
+++ b/actions/st2_prep_release_for_st2_pkg.sh
@@ -127,10 +127,13 @@ if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
     fi
 fi
 
-# Update the st2 version at circle.yml
+# Update 'ST2_GITREV' in 'circle.yml'
 CIRCLE_YML_FILE="circle.yml"
-echo "Setting version in ${CIRCLE_YML_FILE} to ${BRANCH}..."
+echo "[${BRANCH}] Setting 'ST2_GITREV' in '${CIRCLE_YML_FILE}' to '${BRANCH}'..."
 sed -i -e "s/#\s*\(ST2_GITREV:\s*\).*/\1${BRANCH}/" ${CIRCLE_YML_FILE}
+
+# Update 'ST2MISTRAL_GITREV' in 'circle.yml'
+echo "[${BRANCH}] Setting 'ST2MISTRAL_GITREV' in '${CIRCLE_YML_FILE}' to '${MISTRAL_VERSION}'..."
 sed -i -e "s/#\s*\(ST2MISTRAL_GITREV:\s*\).*/\1${MISTRAL_VERSION}/" ${CIRCLE_YML_FILE}
 
 

--- a/actions/st2_prep_release_for_st2_pkg.sh
+++ b/actions/st2_prep_release_for_st2_pkg.sh
@@ -69,7 +69,7 @@ sed -i -e "0,/BRANCH=.*/ s//BRANCH='${BRANCH}'/" ${VERSION_FILE}
 
 MODIFIED=`git status | grep modified || true`
 if [[ ! -z "${MODIFIED}" ]]; then
-    git add ${VERSION_FILE}
+    git add -A
     git commit -qm "Update version info for release - ${VERSION}"
     git push origin master -q
 fi

--- a/actions/st2_prep_release_for_st2_pkg.sh
+++ b/actions/st2_prep_release_for_st2_pkg.sh
@@ -87,7 +87,7 @@ VERSION_FILE="rake/build/environment.rb"
 NEW_VERSION_STR="envpass :gitrev,[ ]*'${BRANCH}',[ ]*from: 'ST2_GITREV'"
 NEW_VERSION_STR_MATCH=`grep "${NEW_VERSION_STR}" ${VERSION_FILE} || true`
 if [[ -z "${NEW_VERSION_STR_MATCH}" ]]; then
-    echo "[${BRANCH}] Setting version in '${VERSION_FILE}' to '${BRANCH}'..."
+    echo "[${BRANCH}] Setting st2 'ST2_GITREV' in '${VERSION_FILE}' to latest stable '${BRANCH}'..."
     sed -i -e "s/\(envpass :gitrev,[ ]*'\).*\(',[ ]*from: 'ST2_GITREV'\)/\1${BRANCH}\2/" ${VERSION_FILE}
 
     NEW_VERSION_STR_MATCH=`grep "${NEW_VERSION_STR}" ${VERSION_FILE} || true`
@@ -102,12 +102,12 @@ VERSION_FILE="rake/build/environment.rb"
 NEW_MISTRAL_VERSION_STR="envpass :gitrev,[ ]*'${MISTRAL_VERSION}',[ ]*from: 'ST2MISTRAL_GITREV'"
 NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
 if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
-    echo "[master] Setting 'ST2MISTRAL_GITREV' branch in '${VERSION_FILE}' to latest stable '${MISTRAL_VERSION}'..."
+    echo "[${BRANCH}] Setting 'ST2MISTRAL_GITREV' branch in '${VERSION_FILE}' to latest stable '${MISTRAL_VERSION}'..."
     sed -i -e "s/\(envpass :gitrev,[ ]*'\).*\(',[ ]*from: 'ST2MISTRAL_GITREV'\)/\1${MISTRAL_VERSION}\2/" ${VERSION_FILE}
 
     NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
     if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
-        >&2 echo "[master] ERROR: Unable to update the 'ST2MISTRAL_GITREV' in '${VERSION_FILE}'."
+        >&2 echo "[${BRANCH}] ERROR: Unable to update the 'ST2MISTRAL_GITREV' in '${VERSION_FILE}'."
         exit 1
     fi
 fi
@@ -117,12 +117,12 @@ VERSION_FILE="rake/build/environment.rb"
 NEW_MISTRAL_VERSION_STR="envpass :mistral_version, '${VERSION}'"
 NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
 if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
-    echo "[master] Setting 'mistral_version' in '${VERSION_FILE}' to latest stable '${VERSION}'..."
+    echo "[${BRANCH}] Setting 'mistral_version' in '${VERSION_FILE}' to latest stable '${VERSION}'..."
     sed -i -e "s/\(envpass :mistral_version, \).*/\1'${VERSION}'/" ${VERSION_FILE}
 
     NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
     if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
-        >&2 echo "[master] ERROR: Unable to update the 'mistral_version' in '${VERSION_FILE}'."
+        >&2 echo "[${BRANCH}] ERROR: Unable to update the 'mistral_version' in '${VERSION_FILE}'."
         exit 1
     fi
 fi

--- a/actions/st2_prep_release_for_st2_pkg.sh
+++ b/actions/st2_prep_release_for_st2_pkg.sh
@@ -60,10 +60,10 @@ if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
     fi
 fi
 
-# Pin bash installer to latest stable 'st2-packages' branch in 'master'
-# Replace only the first occurrence!
+# Update 'BRANCH' to latest stable "vX.Y" branch at 'scripts/st2_bootstrap.sh'
 VERSION_FILE="scripts/st2_bootstrap.sh"
-echo "[master] Setting version in ${VERSION_FILE} to ${BRANCH}..."
+echo "[master] Setting 'BRANCH' version in '${VERSION_FILE}' to latest stable '${BRANCH}'..."
+# Replace only the first occurrence!
 sed -i -e "0,/BRANCH=.*/ s//BRANCH='${BRANCH}'/" ${VERSION_FILE}
 
 

--- a/actions/st2_prep_release_for_st2_pkg.sh
+++ b/actions/st2_prep_release_for_st2_pkg.sh
@@ -47,12 +47,12 @@ VERSION_FILE="rake/build/environment.rb"
 NEW_MISTRAL_VERSION_STR="envpass :gitrev,[ ]*'${MISTRAL_VERSION}',[ ]*from: 'ST2MISTRAL_GITREV'"
 NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
 if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
-    echo "Setting mistral version (1st location) in ${VERSION_FILE} to ${MISTRAL_VERSION}..."
+    echo "[master] Setting mistral version (1st location) in ${VERSION_FILE} to ${MISTRAL_VERSION}..."
     sed -i -e "s/\(envpass :gitrev,[ ]*'\).*\(',[ ]*from: 'ST2MISTRAL_GITREV'\)/\1${MISTRAL_VERSION}\2/" ${VERSION_FILE}
 
     NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
     if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
-        >&2 echo "ERROR: Unable to update the mistral version (1st location) in ${VERSION_FILE}."
+        >&2 echo "[master] ERROR: Unable to update the mistral version (1st location) in ${VERSION_FILE}."
         exit 1
     fi
 fi
@@ -61,20 +61,21 @@ fi
 NEW_MISTRAL_VERSION_STR="envpass :mistral_version, '${VERSION}'"
 NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
 if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
-    echo "Setting mistral version (2nd location) in ${VERSION_FILE} to ${MISTRAL_VERSION}..."
+    echo "[master] Setting mistral version (2nd location) in ${VERSION_FILE} to ${MISTRAL_VERSION}..."
     sed -i -e "s/\(envpass :mistral_version, \).*/\1'${VERSION}'/" ${VERSION_FILE}
 
     NEW_MISTRAL_VERSION_STR_MATCH=`grep "${NEW_MISTRAL_VERSION_STR}" ${VERSION_FILE} || true`
     if [[ -z "${NEW_MISTRAL_VERSION_STR_MATCH}" ]]; then
-        >&2 echo "ERROR: Unable to update the mistral version (2nd location) in ${VERSION_FILE}."
+        >&2 echo "[master] ERROR: Unable to update the mistral version (2nd location) in ${VERSION_FILE}."
         exit 1
     fi
 fi
 
-# 'scripts/st2_bootstrap.sh'
 # Pin bash installer to latest stable 'st2-packages' branch in 'master'
 # Replace only the first occurrence!
-sed "0,/BRANCH=.*/ s//BRANCH='${BRANCH}'/" scripts/st2_bootstrap.sh
+VERSION_FILE="scripts/st2_bootstrap.sh"
+echo "[master] Setting version in ${VERSION_FILE} to ${BRANCH}..."
+sed "0,/BRANCH=.*/ s//BRANCH='${BRANCH}'/" ${VERSION_FILE}
 
 
 MODIFIED=`git status | grep modified || true`
@@ -94,19 +95,19 @@ VERSION_FILE="rake/build/environment.rb"
 NEW_VERSION_STR="envpass :gitrev,[ ]*'${BRANCH}',[ ]*from: 'ST2_GITREV'"
 NEW_VERSION_STR_MATCH=`grep "${NEW_VERSION_STR}" ${VERSION_FILE} || true`
 if [[ -z "${NEW_VERSION_STR_MATCH}" ]]; then
-    echo "Setting version in ${VERSION_FILE} to ${BRANCH}..."
+    echo "[${BRANCH}] Setting version in ${VERSION_FILE} to ${BRANCH}..."
     sed -i -e "s/\(envpass :gitrev,[ ]*'\).*\(',[ ]*from: 'ST2_GITREV'\)/\1${BRANCH}\2/" ${VERSION_FILE}
 
     NEW_VERSION_STR_MATCH=`grep "${NEW_VERSION_STR}" ${VERSION_FILE} || true`
     if [[ -z "${NEW_VERSION_STR_MATCH}" ]]; then
-        >&2 echo "ERROR: Unable to update the st2 version in ${VERSION_FILE}."
+        >&2 echo "[${BRANCH}] ERROR: Unable to update the st2 version in ${VERSION_FILE}."
         exit 1
     fi
 fi
 
 # Update the st2 version at circle.yml
 CIRCLE_YML_FILE="circle.yml"
-echo "Setting version in ${CIRCLE_YML_FILE} to ${BRANCH}..."
+echo "[${BRANCH}] Setting version in ${CIRCLE_YML_FILE} to ${BRANCH}..."
 sed -i -e "s/\(ST2_GITREV:[ ]*\).*/\1${BRANCH}/" ${CIRCLE_YML_FILE}
 sed -i -e "s/\(ST2MISTRAL_GITREV:[ ]*\).*/\1${MISTRAL_VERSION}/" ${CIRCLE_YML_FILE}
 


### PR DESCRIPTION
Related to https://github.com/StackStorm/st2cd/pull/285

Fix for `st2_prep_release_for_st2_pkg` action to pin the version in st2-packages `curl|bash` installer `scripts/st2_bootstrap.sh`
