### PR TITLE
Fix pin dependencies step - make sure python-mistralclient gets added before troveclient

### DIFF
--- a/actions/mistral_create_branch.sh
+++ b/actions/mistral_create_branch.sh
@@ -84,7 +84,7 @@ if [[ $(grep -c . <<< "${REQUIREMENTS}") > 1 ]]; then
 
     # Note: Newer versions of troveclient (>=2.10.0) don't work with our mistralclient fork because of the version changing we do
     # See https://github.com/StackStorm/mistral/pull/24 for context and details
-    sed -i "s/^python-troveclient.*/python-troveclient==2.9.0/g" requirements.txts
+    sed -i "s/^python-troveclient.*/python-troveclient==2.9.0/g" requirements.txt
 
     ${GIT} add requirements.txt
     ${GIT} diff --quiet --exit-code --cached || ${GIT} commit -m "Pin dependencies in requirements.txt"

--- a/actions/mistral_create_branch.sh
+++ b/actions/mistral_create_branch.sh
@@ -82,11 +82,6 @@ if [[ $(grep -c . <<< "${REQUIREMENTS}") > 1 ]]; then
     REQUIREMENTS=`echo "${REQUIREMENTS}" | sed '/https:\/\/github.com\/stackstorm/Id'`
     echo "${REQUIREMENTS}" > requirements.txt
 
-    # Note: python-mistralclient must come before troveclient since troveclient depends on mistralclient
-    # In This case we insert it before python-barbicanclient
-    MISTRALCLIENT_LINE="git+https://github.com/StackStorm/python-mistralclient.git@${BRANCH}#egg=python-mistralclient"
-    grep -q 'python-mistralclient' requirements.txt || sed -i "/python-barbicanclient/ i ${MISTRALCLIENT_LINE}" requirements.txt
-
     # Note: Newer versions of troveclient (>=2.10.0) don't work with our mistralclient fork because of the version changing we do
     # See https://github.com/StackStorm/mistral/pull/24 for context and details
     sed -i "s/^python-troveclient.*/python-troveclient==2.9.0/g" requirements.txts

--- a/actions/mistral_create_branch.sh
+++ b/actions/mistral_create_branch.sh
@@ -81,10 +81,16 @@ if [[ $(grep -c . <<< "${REQUIREMENTS}") > 1 ]]; then
     echo "Updating requirements.txt..."
     REQUIREMENTS=`echo "${REQUIREMENTS}" | sed '/https:\/\/github.com\/stackstorm/Id'`
     echo "${REQUIREMENTS}" > requirements.txt
+
     # Note: python-mistralclient must come before troveclient since troveclient depends on mistralclient
     # In This case we insert it before python-barbicanclient
     MISTRALCLIENT_LINE="git+https://github.com/StackStorm/python-mistralclient.git@${BRANCH}#egg=python-mistralclient"
     grep -q 'python-mistralclient' requirements.txt || sed -i "/python-barbicanclient/ i ${MISTRALCLIENT_LINE}" requirements.txt
+
+    # Note: Newer versions of troveclient (>=2.10.0) don't work with our mistralclient fork because of the version changing we do
+    # See https://github.com/StackStorm/mistral/pull/24 for context and details
+    sed -i "s/^python-troveclient.*/python-troveclient==2.9.0/g" requirements.txts
+
     ${GIT} add requirements.txt
     ${GIT} diff --quiet --exit-code --cached || ${GIT} commit -m "Pin dependencies in requirements.txt"
 fi

--- a/actions/mistral_create_branch.sh
+++ b/actions/mistral_create_branch.sh
@@ -81,7 +81,10 @@ if [[ $(grep -c . <<< "${REQUIREMENTS}") > 1 ]]; then
     echo "Updating requirements.txt..."
     REQUIREMENTS=`echo "${REQUIREMENTS}" | sed '/https:\/\/github.com\/stackstorm/Id'`
     echo "${REQUIREMENTS}" > requirements.txt
-    grep -q 'python-mistralclient' requirements.txt || echo "git+https://github.com/StackStorm/python-mistralclient.git@${BRANCH}#egg=python-mistralclient" >> requirements.txt
+    # Note: python-mistralclient must come before troveclient since troveclient depends on mistralclient
+    # In This case we insert it before python-barbicanclient
+    MISTRALCLIENT_LINE="git+https://github.com/StackStorm/python-mistralclient.git@${BRANCH}#egg=python-mistralclient"
+    grep -q 'python-mistralclient' requirements.txt || sed -i "/python-barbicanclient/ i ${MISTRALCLIENT_LINE}" requirements.txt
     ${GIT} add requirements.txt
     ${GIT} diff --quiet --exit-code --cached || ${GIT} commit -m "Pin dependencies in requirements.txt"
 fi

--- a/actions/mistral_create_branch.sh
+++ b/actions/mistral_create_branch.sh
@@ -82,6 +82,8 @@ if [[ $(grep -c . <<< "${REQUIREMENTS}") > 1 ]]; then
     REQUIREMENTS=`echo "${REQUIREMENTS}" | sed '/https:\/\/github.com\/stackstorm/Id'`
     echo "${REQUIREMENTS}" > requirements.txt
 
+    grep -q 'python-mistralclient' requirements.txt || echo "git+https://github.com/StackStorm/python-mistralclient.git@${BRANCH}#egg=python-mistralclient" >> requirements.txt
+
     # Note: Newer versions of troveclient (>=2.10.0) don't work with our mistralclient fork because of the version changing we do
     # See https://github.com/StackStorm/mistral/pull/24 for context and details
     sed -i "s/^python-troveclient.*/python-troveclient==2.9.0/g" requirements.txt

--- a/actions/workflows/st2_flow_deploy.yaml
+++ b/actions/workflows/st2_flow_deploy.yaml
@@ -24,7 +24,8 @@
         hosts: "st2build001"
         source: "/tmp/{{hostname}}-flow.tar.gz"
         keyfile: "/home/stanley/.ssh/st2_stanley_key"
-        destination: "{{hostname}}:/tmp/"
+        dest_server: "{{hostname}}"
+        destination: "/tmp/"
       on-success: "clean_flow"
     -
       name: "clean_flow"

--- a/actions/workflows/st2_flow_deploy.yaml
+++ b/actions/workflows/st2_flow_deploy.yaml
@@ -24,8 +24,7 @@
         hosts: "st2build001"
         source: "/tmp/{{hostname}}-flow.tar.gz"
         keyfile: "/home/stanley/.ssh/st2_stanley_key"
-        dest_server: "{{hostname}}"
-        destination: "/tmp/"
+        destination: "{{hostname}}:/tmp/"
       on-success: "clean_flow"
     -
       name: "clean_flow"


### PR DESCRIPTION
troveclient depends on mistralclient so if we don't add mistralclient before troveclient, build will fail (we won't be able to satisfy the dependency needed by troveclient).