### PR TITLE
Fix missed version updates in mistral circle.yml

### DIFF
--- a/actions/mistral_create_branch.sh
+++ b/actions/mistral_create_branch.sh
@@ -8,6 +8,7 @@ REPO_ACTION=$4
 REQUIREMENTS=$(echo "$5" | sed 's/\\n/\n/g')
 
 GIT=`which git`
+SHORT_VERSION=`echo ${VERSION} | cut -d "." -f1-2`
 BRANCH=st2-${VERSION}
 
 REGEX="^([0-9])+.([0-9])+.([0-9])+$"
@@ -59,14 +60,18 @@ ${GIT} commit -qm "Update version info for release - ${VERSION}"
 ${GIT} push origin ${BRANCH} -q
 
 
-
+#####################################
+# st2mistral
+#####################################
 echo "Creating branch for st2mistral..."
 cd ${REPO_ACTION}
 ${GIT} checkout -b ${BRANCH}
 ${GIT} push origin ${BRANCH} -q
 
 
-
+#####################################
+# mistral
+#####################################
 echo "Creating branch for mistral..."
 cd ${REPO_MAIN}
 ${GIT} checkout -b ${BRANCH}
@@ -74,7 +79,40 @@ ${GIT} checkout -b ${BRANCH}
 VERSION_FILE="version_st2.py"
 echo "Setting version in ${VERSION_FILE} to ${VERSION}..."
 sed -i -e "s/\(__version__ = \).*/\1'${VERSION}'/" ${VERSION_FILE}
-git add ${VERSION_FILE}
+
+
+# Update 'ST2_PACKAGES_BRANCH' to latest stable "vX.Y" branch at 'circle.yml'
+VERSION_FILE="circle.yml"
+NEW_ST2_PACKAGES_BRANCH_STR="ST2_PACKAGES_BRANCH: v${SHORT_VERSION}"
+NEW_ST2_PACKAGES_BRANCH_STR_MATCH=`grep "${NEW_ST2_PACKAGES_BRANCH_STR}" ${VERSION_FILE} || true`
+if [[ -z "${NEW_ST2_PACKAGES_BRANCH_STR_MATCH}" ]]; then
+    echo "[mistral][${BRANCH}] Setting 'ST2_PACKAGES_BRANCH' in '${VERSION_FILE}' to latest stable 'v${SHORT_VERSION}' branch..."
+    sed -i -e "s/\(ST2_PACKAGES_BRANCH:\).*/\1 v${SHORT_VERSION}/" ${VERSION_FILE}
+
+    NEW_ST2_PACKAGES_BRANCH_STR_MATCH=`grep "${NEW_ST2_PACKAGES_BRANCH_STR}" ${VERSION_FILE} || true`
+    if [[ -z "${NEW_ST2_PACKAGES_BRANCH_STR_MATCH}" ]]; then
+        >&2 echo "[mistral][${BRANCH}] ERROR: Unable to update the 'ST2_PACKAGES_BRANCH' in '${VERSION_FILE}'!"
+        exit 1
+    fi
+fi
+
+# Update 'ST2MISTRAL_GITREV' to latest stable "st2-X.Y.Z" branch at 'circle.yml'
+VERSION_FILE="circle.yml"
+NEW_ST2MISTRAL_GITREV_STR="ST2MISTRAL_GITREV: ${BRANCH}"
+NEW_ST2MISTRAL_GITREV_STR_MATCH=`grep "${NEW_ST2MISTRAL_GITREV_STR}" ${VERSION_FILE} || true`
+if [[ -z "${NEW_ST2MISTRAL_GITREV_STR_MATCH}" ]]; then
+    echo "[mistral][${BRANCH}] Setting 'ST2MISTRAL_GITREV' in '${VERSION_FILE}' to latest stable '${BRANCH}' branch..."
+    sed -i -e "s/\(ST2MISTRAL_GITREV:\).*/\1 ${BRANCH}/" ${VERSION_FILE}
+
+    NEW_ST2MISTRAL_GITREV_STR_MATCH=`grep "${NEW_ST2MISTRAL_GITREV_STR}" ${VERSION_FILE} || true`
+    if [[ -z "${NEW_ST2MISTRAL_GITREV_STR_MATCH}" ]]; then
+        >&2 echo "[mistral][${BRANCH}] ERROR: Unable to update the 'ST2MISTRAL_GITREV' in '${VERSION_FILE}'!"
+        exit 1
+    fi
+fi
+
+
+git add -A
 git commit -qm "Update version info for release - ${VERSION}"
 
 if [[ $(grep -c . <<< "${REQUIREMENTS}") > 1 ]]; then


### PR DESCRIPTION
`ST2_PACKAGES_BRANCH` and `ST2MISTRAL_GITREV` is missing, leading us to build master branch and publish it as stable, when the change is pushed to `mistral` stable branch (for example the first build when the branch is created).

Pin it, same as we do in https://github.com/StackStorm/st2-packages/blob/v2.3/circle.yml#L30

Example changes:
- https://github.com/StackStorm/mistral/pull/25
- https://github.com/StackStorm/mistral/pull/29
- https://github.com/StackStorm/mistral/pull/28