### PR TITLE
Concurrency++ for 'st2_get_installed_version' WF

### DIFF
--- a/actions/workflows/st2_get_installed_version.yaml
+++ b/actions/workflows/st2_get_installed_version.yaml
@@ -29,7 +29,7 @@ st2cd.st2_get_installed_version:
 
         get_version_centos:
             with-items: package in <% $.packages %>
-            concurrency: 1
+            concurrency: <% $.packages.count() %>
             action: core.remote_sudo
             input:
                 hosts: <% $.host %>
@@ -39,7 +39,7 @@ st2cd.st2_get_installed_version:
 
         get_version_redhat:
             with-items: package in <% $.packages %>
-            concurrency: 1
+            concurrency: <% $.packages.count() %>
             action: core.remote_sudo
             input:
                 hosts: <% $.host %>
@@ -49,7 +49,7 @@ st2cd.st2_get_installed_version:
 
         get_version_ubuntu:
             with-items: package in <% $.packages %>
-            concurrency: 1
+            concurrency: <% $.packages.count() %>
             action: core.remote_sudo
             input:
                 hosts: <% $.host %>


### PR DESCRIPTION
Just a random find.

Let the version lookup work in parallel, based on number of packages, instead of running one-after-another with `concurrency: 1`.