### PR TITLE
Fix 'test_quickstart' workflow tasks running twice

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -63,6 +63,7 @@ workflows:
                     host: <% $.host_ip %>
                     env: <% $.st2_cli_env %>
                     protocol: <% $.protocol %>
+                    st2_cli_args: token=<% $.env.get(ST2_AUTH_TOKEN) %> protocol=<% $.protocol %>
                 on-success:
                     # Run Mistral tests after basic and quickstart
                     - run_mistral_tests
@@ -129,21 +130,15 @@ workflows:
 
 
     test_quickstart:
-        type: reverse
+        type: direct
         input:
             - host
             - env
             - protocol
+            - st2_cli_args
         tasks:
-            init:
-                action: std.noop
-                description: "Init task that should be executed first. Make sure other tasks depends on it."
-                publish:
-                    st2_cli_args: token=<% $.env.get(ST2_AUTH_TOKEN) %> protocol=<% $.protocol %>
-
             test_quickstart:
                 action: core.remote
-                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -153,7 +148,6 @@ workflows:
                 #     - test_quickstart_key
             test_quickstart_key:
                 action: core.remote
-                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -162,7 +156,6 @@ workflows:
                 #     - test_quickstart_rules
             test_quickstart_rules:
                 action: core.remote
-                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -172,7 +165,6 @@ workflows:
                 #     - test_quickstart_packs
             test_quickstart_packs:
                 action: core.remote
-                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -182,7 +174,6 @@ workflows:
                 #     - test_quickstart_local_script
             test_quickstart_local_script:
                 action: core.remote
-                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -192,7 +183,6 @@ workflows:
                 #     - test_quickstart_remote_script
             test_quickstart_remote_script:
                 action: core.remote
-                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -202,7 +192,6 @@ workflows:
                 #     - test_quickstart_passive_sensor
             test_quickstart_passive_sensor:
                 action: core.remote
-                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -212,7 +201,6 @@ workflows:
                 #     - test_quickstart_polling_sensor
             test_quickstart_polling_sensor:
                 action: core.remote
-                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -222,7 +210,6 @@ workflows:
                 #     - test_quickstart_python
             test_quickstart_python:
                 action: core.remote
-                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -232,7 +219,6 @@ workflows:
                 #     - test_quickstart_key_triggers
             test_quickstart_key_triggers:
                 action: core.remote
-                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -242,7 +228,6 @@ workflows:
                 #    - test_quickstart_trace
             test_quickstart_trace:
                 action: core.remote
-                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -252,7 +237,6 @@ workflows:
                 #     - test_quickstart_run_pack_tests_tool
             test_quickstart_run_pack_tests_tool:
                 action: core.remote
-                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -263,7 +247,6 @@ workflows:
                 #    - test_quickstart_timer_rules
             test_quickstart_timer_rules:
                 action: core.remote
-                requires: [init, test_quickstart_run_pack_tests_tool]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -259,12 +259,11 @@ workflows:
                     # Note: This test is only available and working in StackStorm >= 2.3dev
                     cmd: "st2 action get tests.test_run_pack_tests_tool ; if [ $? -eq 0 ]; then st2 run tests.test_run_pack_tests_tool <% $.st2_cli_args %>; else echo 'run_pack_tests_tool tests not available'; fi"
                     timeout: 600
-                # Keep timer_rules sequential
-                on-success:
-                    - test_quickstart_timer_rules
+                # on-success:
+                #    - test_quickstart_timer_rules
             test_quickstart_timer_rules:
                 action: core.remote
-                requires: [init]
+                requires: [init, test_quickstart_run_pack_tests_tool]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -58,12 +58,11 @@ workflows:
                 # on-success:
                 #     - run_quickstart_tests
             run_quickstart_tests:
-                workflow: test_quickstart
+                workflow: test_quickstart_wf
                 input:
                     host: <% $.host_ip %>
                     env: <% $.st2_cli_env %>
                     protocol: <% $.protocol %>
-                    st2_cli_args: token=<% $.env.get(ST2_AUTH_TOKEN) %> protocol=<% $.protocol %>
                 on-success:
                     # Run Mistral tests after basic and quickstart
                     - run_mistral_tests
@@ -129,14 +128,32 @@ workflows:
                     cmd: st2 run core.remote hosts=<% $.host %> hostname
 
 
-    test_quickstart:
+    test_quickstart_wf:
         type: direct
         input:
             - host
             - env
             - protocol
-            - st2_cli_args
         tasks:
+            init:
+                action: std.noop
+                publish:
+                    st2_cli_args: token=<% $.env.get(ST2_AUTH_TOKEN) %> protocol=<% $.protocol %>
+                on-success:
+                    - test_quickstart
+                    - test_quickstart_key
+                    - test_quickstart_rules
+                    - test_quickstart_packs
+                    - test_quickstart_local_script
+                    - test_quickstart_remote_script
+                    - test_quickstart_passive_sensor
+                    - test_quickstart_polling_sensor
+                    - test_quickstart_python
+                    - test_quickstart_key_triggers
+                    - test_quickstart_trace
+                    - test_quickstart_run_pack_tests_tool
+                    # Keep timer_rules sequential
+                    # - test_quickstart_timer_rules
             test_quickstart:
                 action: core.remote
                 input:
@@ -243,8 +260,9 @@ workflows:
                     # Note: This test is only available and working in StackStorm >= 2.3dev
                     cmd: "st2 action get tests.test_run_pack_tests_tool ; if [ $? -eq 0 ]; then st2 run tests.test_run_pack_tests_tool <% $.st2_cli_args %>; else echo 'run_pack_tests_tool tests not available'; fi"
                     timeout: 600
-                # on-success:
-                #    - test_quickstart_timer_rules
+                # Keep timer_rules sequential
+                on-success:
+                    - test_quickstart_timer_rules
             test_quickstart_timer_rules:
                 action: core.remote
                 input:

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -129,7 +129,7 @@ workflows:
 
 
     test_quickstart:
-        type: direct
+        type: reverse
         input:
             - host
             - env
@@ -137,25 +137,13 @@ workflows:
         tasks:
             init:
                 action: std.noop
+                description: "Init task that should be executed first. Make sure other tasks depends on it."
                 publish:
                     st2_cli_args: token=<% $.env.get(ST2_AUTH_TOKEN) %> protocol=<% $.protocol %>
-                on-success:
-                    - test_quickstart
-                    - test_quickstart_key
-                    - test_quickstart_rules
-                    - test_quickstart_packs
-                    - test_quickstart_local_script
-                    - test_quickstart_remote_script
-                    - test_quickstart_passive_sensor
-                    - test_quickstart_polling_sensor
-                    - test_quickstart_python
-                    - test_quickstart_key_triggers
-                    - test_quickstart_trace
-                    - test_quickstart_run_pack_tests_tool
-                    # Keep timer_rules sequential
-                    # - test_quickstart_timer_rules
+
             test_quickstart:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -165,6 +153,7 @@ workflows:
                 #     - test_quickstart_key
             test_quickstart_key:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -173,6 +162,7 @@ workflows:
                 #     - test_quickstart_rules
             test_quickstart_rules:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -182,6 +172,7 @@ workflows:
                 #     - test_quickstart_packs
             test_quickstart_packs:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -191,6 +182,7 @@ workflows:
                 #     - test_quickstart_local_script
             test_quickstart_local_script:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -200,6 +192,7 @@ workflows:
                 #     - test_quickstart_remote_script
             test_quickstart_remote_script:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -209,6 +202,7 @@ workflows:
                 #     - test_quickstart_passive_sensor
             test_quickstart_passive_sensor:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -218,6 +212,7 @@ workflows:
                 #     - test_quickstart_polling_sensor
             test_quickstart_polling_sensor:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -227,6 +222,7 @@ workflows:
                 #     - test_quickstart_python
             test_quickstart_python:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -236,6 +232,7 @@ workflows:
                 #     - test_quickstart_key_triggers
             test_quickstart_key_triggers:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -245,6 +242,7 @@ workflows:
                 #    - test_quickstart_trace
             test_quickstart_trace:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -254,6 +252,7 @@ workflows:
                 #     - test_quickstart_run_pack_tests_tool
             test_quickstart_run_pack_tests_tool:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>
@@ -265,6 +264,7 @@ workflows:
                     - test_quickstart_timer_rules
             test_quickstart_timer_rules:
                 action: core.remote
+                requires: [init]
                 input:
                     hosts: <% $.host %>
                     env: <% $.env %>


### PR DESCRIPTION
Previous PR https://github.com/StackStorm/st2cd/pull/296 introduced regression by running the same `test_quickstart` tasks twice.



![](https://i.imgur.com/6tm14WF.png)

Trying to find the reason.