### PR TITLE
Increase timeout when uploading docs to s3

### DIFF
--- a/actions/workflows/bwc_docs.yaml
+++ b/actions/workflows/bwc_docs.yaml
@@ -49,6 +49,7 @@
         location: "{% if branch == 'master' %}/latest/{% elif version|string() == st2kv.system.st2_stable_version|string() %}/{% endif %}"
         bucket: "{{docs_url}}"
         version: "/{{version}}/"
+        timeout: 600
       on-success: "clean_repo"
       on-failure: "clean_repo"
     -

--- a/actions/workflows/st2_docs.yaml
+++ b/actions/workflows/st2_docs.yaml
@@ -57,6 +57,7 @@
         location: "{% if branch == 'master' %}/latest/{% elif version|string() == st2kv.system.st2_stable_version|string() %}/{% endif %}"
         bucket: "{% if environment == 'production' %}docs.stackstorm.com{% else %}{{docs_url}}{% endif %}"
         version: "/{{version}}/"
+        timeout: 600
       on-success: "clean_repo"
       on-failure: "clean_repo"
     -


### PR DESCRIPTION
The command times out at default 60 seconds. Increate the timeout to 600 seconds to give the command more time.