### PR TITLE
Use fqdn for st2cicd

### DIFF
--- a/actions/workflows/mistral_release_candidate.yaml
+++ b/actions/workflows/mistral_release_candidate.yaml
@@ -17,7 +17,7 @@ st2cd.mistral_release_candidate:
         - notify_failure_channels:
             - "#thunderdome"
             - "#stackstorm"
-        - webui_base_url: "https://st2cicd"
+        - webui_base_url: "https://st2cicd.uswest2.stackstorm.net"
 
     task-defaults:
         on-error:

--- a/rules/st2cd_slack_docs.yaml
+++ b/rules/st2cd_slack_docs.yaml
@@ -28,6 +28,6 @@
                 {% endif %}
                 BRANCH: {{trigger.parameters.branch}}
                 ````
-                https://st2cicd/#/history/{{trigger.execution_id}}/general
+                https://st2cicd.uswest2.stackstorm.net/#/history/{{trigger.execution_id}}/general
 
 


### PR DESCRIPTION
Similar to https://github.com/StackStorm/st2ci/pull/114,

Use FQDN for `st2cicd` by default to get the best from https://github.com/StackStorm/ops-infra/issues/113 feature.