### PR TITLE
Fix a race between test_quickstart_key_triggers and test_quickstart_python tests

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -246,7 +246,6 @@ workflows:
                     timeout: 600
                 on-success:
                     - test_quickstart_python
-                    - test_quickstart_key_triggers
                     - test_quickstart_trace
                     - test_quickstart_run_pack_tests_tool
             test_quickstart_python:
@@ -258,15 +257,6 @@ workflows:
                     timeout: 600
                 # on-success:
                 #     - test_quickstart_key_triggers
-            test_quickstart_key_triggers:
-                action: core.remote
-                input:
-                    hosts: <% $.host %>
-                    env: <% $.env %>
-                    cmd: st2 run tests.test_key_triggers <% $.st2_cli_args %>
-                    timeout: 600
-                # on-success:
-                #    - test_quickstart_trace
             test_quickstart_trace:
                 action: core.remote
                 input:
@@ -284,8 +274,19 @@ workflows:
                     # Note: This test is only available and working in StackStorm >= 2.3dev
                     cmd: "st2 action get tests.test_run_pack_tests_tool ; if [ $? -eq 0 ]; then st2 run tests.test_run_pack_tests_tool <% $.st2_cli_args %>; else echo 'run_pack_tests_tool tests not available'; fi"
                     timeout: 600
-                # Keep timer_rules sequential
+                # Keep key_triggers and timer_rules tests sequential.
+                # test_quickstart_key_triggers conflicts with test_quickstart_python (race) so
+                # they can't run at the same time.
                 on-success:
+                    - test_quickstart_key_triggers
+            test_quickstart_key_triggers:
+                action: core.remote
+                input:
+                    hosts: <% $.host %>
+                    env: <% $.env %>
+                    cmd: st2 run tests.test_key_triggers <% $.st2_cli_args %>
+                    timeout: 600
+                 on-success:
                     - test_quickstart_timer_rules
             test_quickstart_timer_rules:
                 action: core.remote
@@ -294,7 +295,6 @@ workflows:
                     env: <% $.env %>
                     cmd: st2 run tests.test_timer_rule <% $.st2_cli_args %>
                     timeout: 600
-
 
     test_mistral:
         type: direct


### PR DESCRIPTION
There is race condition between `test_quickstart_key_triggers` and `test_quickstart_python` tests so they can't run in parallel.

First test relies on a trigger instance being injected into the system, but second test also injects some trigger instances in the system and depending on the timing, etc. first test can fail because it will retrieve wrong trigger instance.

This pull request changes it to run `test_quickstart_key_triggers` at the end after python one in the sequential manner.

In the future we could ideally refactor the `key_triggers` test so it could still run in parallel, but this would need more rework (right now it just retrieves last trigger instance).

/cc @humblearner 