### PR TITLE
Merge st2.conf with st2.ci.conf from st2tests

### DIFF
--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -49,9 +49,10 @@ fi
 echo "Installing Packs: tests, asserts, fixtures, webui..."
 sudo cp -R st2tests/packs/* /opt/stackstorm/packs/
 
-echo "Copy st2 CI configuration if it exists..."
+echo "Apply st2 CI configuration if it exists..."
 if [ -f st2tests/conf/st2.ci.conf ]; then
-    sudo cp -f st2tests/conf/st2.ci.conf /etc/st2/st2.conf
+    sudo cp -f /etc/st2/st2.conf /etc/st2/st2.conf.bkup
+    sudo crudini --merge  /etc/st2/st2.conf < st2tests/conf/st2.ci.conf
 fi
 
 sudo cp -R /usr/share/doc/st2/examples /opt/stackstorm/packs/


### PR DESCRIPTION
Simply replacing st2.conf with st2.ci.conf won't work because we muck with stock st2.conf in installer scripts (like adding mongo password etc). So I am merging in the CI st2.conf. 