### PR TITLE
Set st2_version in package.json to release version

### DIFF
--- a/actions/bwc_prep_release_for_gui.sh
+++ b/actions/bwc_prep_release_for_gui.sh
@@ -43,21 +43,19 @@ echo "Creating new branch ${BRANCH}..."
 git checkout -b ${BRANCH} origin/master
 
 
-# SET NEW BWC VERSION INFO
-VERSION_FILE="circle.yml"
-VERSION_STR="git clone -b ${BRANCH} https:\/\/github.com"
+# SET NEW ST2 VERSION INFO
+VERSION_FILE="package.json"
+VERSION_STR="\"st2_version\": \"${VERSION}\""
 
-if [ -f ${VERSION_FILE} ]; then
+VERSION_STR_MATCH=`grep "${VERSION_STR}" ${VERSION_FILE} || true`
+if [[ -z "${VERSION_STR_MATCH}" ]]; then
+    echo "Setting version in ${VERSION_FILE} to ${VERSION}..."
+    sed -i -e "s/\(^  \"st2_version\": \"\).*\(\"\)/\1${VERSION}\2/" ${VERSION_FILE}
+
     VERSION_STR_MATCH=`grep "${VERSION_STR}" ${VERSION_FILE} || true`
     if [[ -z "${VERSION_STR_MATCH}" ]]; then
-        echo "Setting version in ${VERSION_FILE} to ${VERSION}..."
-        sed -i -e "s/git clone https:\/\/github.com/${VERSION_STR}/g" ${VERSION_FILE}
-
-        VERSION_STR_MATCH=`grep "${VERSION_STR}" ${VERSION_FILE} || true`
-        if [[ -z "${VERSION_STR_MATCH}" ]]; then
-            >&2 echo "ERROR: Unable to update the bwc version in ${VERSION_FILE}."
-            exit 1
-        fi
+        >&2 echo "ERROR: Unable to update the st2 version in ${VERSION_FILE}."
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
circle.yml has been moved and now uses CIRCLE_BRANCH env variable https://github.com/StackStorm/bwc-ui/blob/master/.circleci/config.yml#L56

We still have to set st2_version in package.json just like st2web

Rip off from https://github.com/StackStorm/st2cd/blob/master/actions/st2_prep_release_for_gui.sh#L46

## Tests: 

```
vagrant@arkham:/mnt/src/storm/st2$ grep "st2_version" package.json
  "st2_version": "2.7dev",
vagrant@arkham:/mnt/src/storm/st2$ ./test_replace.sh
Setting version in package.json to 2.9.0...
"st2_version": "2.9.0",
vagrant@arkham:/mnt/src/storm/st2$ grep "st2_version" package.json
  "st2_version": "2.9.0",
vagrant@arkham:/mnt/src/storm/st2$ cat test_replace.sh
#!/bin/bash

set -e

VERSION="2.9.0"
VERSION_FILE="package.json"
VERSION_STR="\"st2_version\": \"${VERSION}\""

VERSION_STR_MATCH=`grep "${VERSION_STR}" ${VERSION_FILE} || true`
if [[ -z "${VERSION_STR_MATCH}" ]]; then
    echo "Setting version in ${VERSION_FILE} to ${VERSION}..."
    sed -i -e "s/\(^  \"st2_version\": \"\).*\(\"\)/\1${VERSION}\2/" ${VERSION_FILE}

    VERSION_STR_MATCH=`grep "${VERSION_STR}" ${VERSION_FILE} || true`
    echo ${VERSION_STR_MATCH}
    if [[ -z "${VERSION_STR_MATCH}" ]]; then
        >&2 echo "ERROR: Unable to update the st2 version in ${VERSION_FILE}."
        exit 1
    fi
fi
vagrant@arkham:/mnt/src/storm/st2$
```