### PR TITLE
Add a step to set dev version in bwc-ui

### DIFF
--- a/actions/bwc_chg_ver_for_bwc_ui.sh
+++ b/actions/bwc_chg_ver_for_bwc_ui.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+PROJECT=$1
+VERSION=$2
+FORK=$3
+LOCAL_REPO=$4
+GIT_REPO="git@github.com:${FORK}/${PROJECT}.git"
+SHORT_VERSION=`echo ${VERSION} | cut -d "." -f1-2`
+DEV_VERSION="${SHORT_VERSION}dev"
+BRANCH="v${SHORT_VERSION}"
+CWD=`pwd`
+
+
+# CHECK IF BRANCH EXISTS
+BRANCH_EXISTS=`git ls-remote --heads ${GIT_REPO} | grep refs/heads/${BRANCH} || true`
+
+if [[ ! -z "${BRANCH_EXISTS}" ]]; then
+    >&2 echo "ERROR: Branch ${BRANCH} already exist in ${GIT_REPO}."
+    exit 1
+fi
+
+
+# GIT CLONE AND BRANCH
+if [[ -z ${LOCAL_REPO} ]]; then
+    CURRENT_TIMESTAMP=`date +'%s'`
+    RANDOM_NUMBER=`awk -v min=100 -v max=999 'BEGIN{srand(); print int(min+rand()*(max-min+1))}'`
+    LOCAL_REPO=${PROJECT}_${CURRENT_TIMESTAMP}_${RANDOM_NUMBER}
+fi
+
+echo "Cloning ${GIT_REPO} to ${LOCAL_REPO}..."
+
+if [ -d "${LOCAL_REPO}" ]; then
+    rm -rf ${LOCAL_REPO}
+fi
+
+git clone ${GIT_REPO} ${LOCAL_REPO}
+
+cd ${LOCAL_REPO}
+echo "Currently at directory `pwd`..."
+
+echo "Creating new branch ${BRANCH}..."
+git checkout -b ${BRANCH} origin/master
+
+
+# SET NEW ST2 VERSION INFO
+VERSION_FILE="package.json"
+VERSION_STR="\"st2_version\": \"${VERSION}\""
+
+VERSION_STR_MATCH=`grep "${VERSION_STR}" ${VERSION_FILE} || true`
+if [[ -z "${VERSION_STR_MATCH}" ]]; then
+    echo "Setting version in ${VERSION_FILE} to ${VERSION}..."
+    sed -i -e "s/\(^  \"st2_version\": \"\).*\(\"\)/\1${VERSION}\2/" ${VERSION_FILE}
+
+    VERSION_STR_MATCH=`grep "${VERSION_STR}" ${VERSION_FILE} || true`
+    if [[ -z "${VERSION_STR_MATCH}" ]]; then
+        >&2 echo "ERROR: Unable to update the st2 version in ${VERSION_FILE}."
+        exit 1
+    fi
+fi
+
+MODIFIED=`git status | grep modified || true`
+if [[ ! -z "${MODIFIED}" ]]; then
+    git add ${VERSION_FILE}
+    git commit -qm "Update version info for release - ${VERSION}"
+    git push origin ${BRANCH} -q
+fi
+
+
+# CLEANUP
+cd ${CWD}
+rm -rf ${LOCAL_REPO}

--- a/actions/bwc_prep_dev_for_bwc_ui.meta.yaml
+++ b/actions/bwc_prep_dev_for_bwc_ui.meta.yaml
@@ -1,0 +1,45 @@
+---
+name: bwc_prep_dev_for_bwc_ui
+description: Prepare the BWC GUI repo for next iteration of development
+enabled: true
+runner_type: remote-shell-script
+entry_point: bwc_chg_ver_for_bwc_ui.sh
+parameters:
+    project:
+        type: string
+        description: Project name for st2
+        required: true
+        enum:
+            - bwc-ui
+        position: 0
+    version:
+        type: string
+        description: Version to use for the next release. Should include the patch e.g. 0.1.0
+        required: true
+        position: 1
+    fork:
+        type: string
+        description: Fork to use
+        default: StackStorm
+        position: 2
+    branch:
+        type: string
+        description: Branch to update
+        default: master
+        position: 3
+    local_repo:
+        type: string
+        description: Location where to clone the repo. Programmatically determined if not provided.
+        position: 4
+    dir:
+        immutable: true
+        default: /home/stanley/
+    sudo:
+        immutable: true
+        default: false
+    cmd:
+        immutable: true
+        default: ""
+    kwarg_op:
+        immutable: true
+        default: "--"

--- a/actions/workflows/bwc_prep_dev.yaml
+++ b/actions/workflows/bwc_prep_dev.yaml
@@ -62,6 +62,17 @@ st2cd.bwc_prep_dev:
                 local_repo: <% 'st2enterprise_auth_ldap_' + $.local_repo_sfx %>
                 hosts: <% $.host %>
                 cwd: <% $.cwd %>
+            on-success:
+                - prep_bwc_ui
+        prep_bwc_ui:
+            action: st2cd.bwc_prep_dev_for_bwc_ui
+            input:
+                project: bwc-ui
+                version: <% $.dev_version %>
+                fork: <% $.fork %>
+                local_repo: <% 'bwc-ui_' + $.local_repo_sfx %>
+                hosts: <% $.host %>
+                cwd: <% $.cwd %>
         #    on-success:
         #        - prep_bwc_ipfabric_suite
         # prep_bwc_ipfabric_suite:


### PR DESCRIPTION
## tests
```
(virtualenv) ubuntu@arkham /tmp ❯❯❯ st2 run st2cd.bwc_prep_dev_for_bwc_ui hosts=localhost project=bwc-ui version=2.8dev
..
id: 5a78ea461e2e242a7c528161
status: failed
parameters:
  hosts: localhost
  project: bwc-ui
  version: 2.8dev
result:
  localhost:
    failed: true
    return_code: 128
    stderr: "Cloning into 'master'...
Switched to a new branch 'v2.8dev'

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <stanley@arkham>) not allowed"
    stdout: "Cloning git@github.com:StackStorm/bwc-ui.git to master...
Currently at directory /tmp/master...
Creating new branch v2.8dev...
Branch v2.8dev set up to track remote branch master from origin.
Version str match:
Setting version in package.json to 2.8dev..."
    succeeded: false
(virtualenv) ubuntu@arkham /tmp ❯❯❯
```

```
(virtualenv) ubuntu@arkham /t/master ❯❯❯ grep "2.8dev" package.json                                                  v2.8dev ✚
  "st2_version": "2.8dev",
(virtualenv) ubuntu@arkham /t/master ❯❯❯```