### PR TITLE
Release new branch for bwc-installer

### DIFF
--- a/actions/bwc_prep_release_for_bwc_installer.meta.yaml
+++ b/actions/bwc_prep_release_for_bwc_installer.meta.yaml
@@ -1,0 +1,38 @@
+---
+name: bwc_prep_release_for_bwc_installer
+description: Prepare the bwc-installer repo for release
+enabled: true
+runner_type: remote-shell-script
+entry_point: bwc_prep_release_for_bwc_installer.sh
+parameters:
+    project:
+        type: string
+        description: Project name for bwc-installer
+        default: bwc-installer
+        position: 0
+    version:
+        type: string
+        description: Version to use for the release. Should include the patch e.g. 0.1.0
+        required: true
+        position: 1
+    fork:
+        type: string
+        description: Fork to use
+        default: StackStorm
+        position: 2
+    local_repo:
+        type: string
+        description: Location where to clone the repo. Programmatically determined if not provided.
+        position: 3
+    dir:
+        immutable: true
+        default: /home/stanley/
+    sudo:
+        immutable: true
+        default: false
+    cmd:
+        immutable: true
+        default: ""
+    kwarg_op:
+        immutable: true
+        default: "--"

--- a/actions/bwc_prep_release_for_bwc_installer.sh
+++ b/actions/bwc_prep_release_for_bwc_installer.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+PROJECT=$1
+VERSION=$2
+FORK=$3
+LOCAL_REPO=$4
+GIT_REPO="git@github.com:${FORK}/${PROJECT}.git"
+SHORT_VERSION=`echo ${VERSION} | cut -d "." -f1-2`
+BRANCH="v${SHORT_VERSION}"
+CWD=`pwd`
+
+
+# CHECK IF BRANCH EXISTS
+BRANCH_EXISTS=`git ls-remote --heads ${GIT_REPO} | grep refs/heads/${BRANCH} || true`
+
+if [[ ! -z "${BRANCH_EXISTS}" ]]; then
+    >&2 echo "ERROR: Branch ${BRANCH} already exist in ${GIT_REPO}."
+    exit 1
+fi
+
+
+# GIT CLONE AND BRANCH
+if [[ -z ${LOCAL_REPO} ]]; then
+    CURRENT_TIMESTAMP=`date +'%s'`
+    RANDOM_NUMBER=`awk -v min=100 -v max=999 'BEGIN{srand(); print int(min+rand()*(max-min+1))}'`
+    LOCAL_REPO=${PROJECT}_${CURRENT_TIMESTAMP}_${RANDOM_NUMBER}
+fi
+
+echo "Cloning ${GIT_REPO} to ${LOCAL_REPO}..."
+
+if [ -d "${LOCAL_REPO}" ]; then
+    rm -rf ${LOCAL_REPO}
+fi
+
+git clone ${GIT_REPO} ${LOCAL_REPO}
+
+cd ${LOCAL_REPO}
+echo "Currently at directory `pwd`..."
+
+
+# CREATE RELEASE BRANCH AND SET NEW ST2 VERSION INFO
+echo "Creating new branch ${BRANCH}..."
+git checkout -b ${BRANCH} origin/master
+
+# XXX: No changes need to be made to the repo today. 
+
+echo "Pushing branch ${BRANCH} to github"
+git push origin ${BRANCH}
+
+# CLEANUP
+cd ${CWD}
+rm -rf ${LOCAL_REPO}

--- a/actions/workflows/bwc_prep_release.yaml
+++ b/actions/workflows/bwc_prep_release.yaml
@@ -122,6 +122,18 @@ st2cd.bwc_prep_release:
                 local_repo: <% 'bwc_ipfabric_docs_' + $.local_repo_sfx %>
                 hosts: <% $.host %>
                 cwd: <% $.cwd %>
+            on-success:
+                - prep_bwc_installer
+        
+        prep_bwc_installer:
+            action: st2cd.bwc_prep_release_for_bwc_installer
+            input:
+                project: bwc-installer
+                version: <% $.version %>
+                fork: <% $.fork %>
+                local_repo: <% 'bwc-installer_' + $.local_repo_sfx %>
+                hosts: <% $.host %>
+                cwd: <% $.cwd %>
 
 
         cleanup_on_failure:


### PR DESCRIPTION
## Tests

```
(virtualenv) ubuntu@arkham /m/s/s/st2 ❯❯❯ st2 run st2cd.bwc_prep_release_for_bwc_installer hosts=localhost project=bwc-installer version=2.8.testing
..
id: 5a78ecd21e2e2445839fd28a
status: succeeded
parameters:
  hosts: localhost
  project: bwc-installer
  version: 2.8.testing
result:
  localhost:
    failed: false
    return_code: 0
    stderr: 'Cloning into ''bwc-installer_1517874387_335''...
      Switched to a new branch ''v2.8'''
    stdout: 'Cloning git@github.com:StackStorm/bwc-installer.git to bwc-installer_1517874387_335...
      Currently at directory /tmp/bwc-installer_1517874387_335...
      Creating new branch v2.8...
      Branch v2.8 set up to track remote branch master from origin.
      Pushing branch v2.8 to github'
    succeeded: true
(virtualenv) ubuntu@arkham /m/s/s/st2 ❯❯❯
```