### PR TITLE
Make sure latest version of virtualenv is used for make bwcdocs target

### DIFF
--- a/actions/workflows/bwc_docs.yaml
+++ b/actions/workflows/bwc_docs.yaml
@@ -37,7 +37,7 @@
       params:
         hosts: "{{build_server}}"
         timeout: 2000
-        cmd: "cd {{repodir}} && make bwcdocs"
+        cmd: 'cd {{repodir}} && sudo pip install --upgrade "virtualenv==15.1.0" && make bwcdocs'
       on-success: "s3cmd_docs"
       on-failure: "clean_repo"
     -


### PR DESCRIPTION
Same as https://github.com/StackStorm/st2cd/pull/328 for but bwc docs.

Eventually we should also port this workflow step to be a remote shell script action so it's consistent with st2 docs target.