### PR TITLE
Fix a bug with mistral version being duplicated and not set correctly in setup.cfg

### DIFF
--- a/actions/mistral_create_branch.sh
+++ b/actions/mistral_create_branch.sh
@@ -53,7 +53,7 @@ ${GIT} add ${VERSION_FILE}
 
 VERSION_FILE="setup.cfg"
 echo "Setting version in ${VERSION_FILE} to ${VERSION}..."
-sed -i "s/^name = python-mistralclient/name = python-mistralclient\nversion = ${VERSION}/g" ${VERSION_FILE}
+sed -i "s/^version = .*$/version = ${VERSION}/g" ${VERSION_FILE}
 ${GIT} add ${VERSION_FILE}
 
 ${GIT} commit -qm "Update version info for release - ${VERSION}"


### PR DESCRIPTION
Some Python 3 tests started to fail (https://travis-ci.org/StackStorm/st2/jobs/377378531) because Python 3 is more strict and throws early with errors like that (much better, imo).

It turns out the sed expression we use doesn't correctly set the version - instead of replacing / setting the version, it always appended a new "version" attribute.

See https://github.com/StackStorm/python-mistralclient/commit/2732e3dc14c0936e65728ac76099e0e5a625da0c for example.

This pull request fixes that.