### PR TITLE
Fix mistral_create_branch script so it handles major, minor and patch versions correctly

### DIFF
--- a/actions/mistral_create_branch.sh
+++ b/actions/mistral_create_branch.sh
@@ -53,7 +53,11 @@ ${GIT} add ${VERSION_FILE}
 
 VERSION_FILE="setup.cfg"
 echo "Setting version in ${VERSION_FILE} to ${VERSION}..."
-sed -i "s/^version = .*$/version = ${VERSION}/g" ${VERSION_FILE}
+# 1. First delete all "version = " occurences - this way we handle both - minor and patch
+# release correctly
+sed -i '/^version = .*$/d' ${VERSION_FILE}
+# 2. Append a version
+sed -i "s/^name = python-mistralclient/name = python-mistralclient\nversion = ${VERSION}/g" ${VERSION_FILE}
 ${GIT} add ${VERSION_FILE}
 
 ${GIT} commit -qm "Update version info for release - ${VERSION}"


### PR DESCRIPTION
#333 fixed an issue in this script with not handling patch versions correctly, but it broke it for major and minor versions (where file doesn't contain `version =` line).

This pull request fixes it so it now handles all the scenarios (major, minor - line doesn't exist yet, patch - line exist) correctly.