### PR TITLE
Set / bump __version__ for all the runner packages during the release

### DIFF
--- a/actions/st2_chg_ver_for_st2.sh
+++ b/actions/st2_chg_ver_for_st2.sh
@@ -38,14 +38,18 @@ git clone -b ${BRANCH} --single-branch ${GIT_REPO} ${LOCAL_REPO}
 cd ${LOCAL_REPO}
 echo "Currently at directory `pwd`..."
 
-
 # SET ST2 VERSION INFO
-INIT_FILES=(
+COMMON_INIT_FILES=(
     "st2common/st2common/__init__.py"
     "st2client/st2client/__init__.py"
 )
 
-for INIT_FILE in "${INIT_FILES[@]}"
+# Add all the runners
+RUNNER_INIT_FILES=($(find contrib/runners -maxdepth 3 -name __init__.py -not -path "*tests*" -not -path "*query*" -not -path "*callback*" -not -path "*functions*"))
+
+ALL_INIT_FILES=("${COMMON_INIT_FILES[@]}" "${RUNNER_INIT_FILES[@]}")
+
+for INIT_FILE in "${ALL_INIT_FILES[@]}"
 do
     if [[ ! -e "${INIT_FILE}" ]]; then
         >&2 echo "ERROR: Version file ${INIT_FILE} does not exist."

--- a/actions/st2_chg_ver_for_st2.sh
+++ b/actions/st2_chg_ver_for_st2.sh
@@ -45,12 +45,14 @@ COMMON_INIT_FILES=(
 )
 
 # Add all the runners
-RUNNER_INIT_FILES=($(find contrib/runners -maxdepth 3 -name __init__.py -not -path "*tests*" -not -path "*query*" -not -path "*callback*" -not -path "*functions*"))
+RUNNER_INIT_FILES=($(find contrib/runners -mindepth 3 -maxdepth 3 -name __init__.py -not -path "*tests*" -not -path "*query*" -not -path "*callback*" -not -path "*functions*"))
 
 ALL_INIT_FILES=("${COMMON_INIT_FILES[@]}" "${RUNNER_INIT_FILES[@]}")
 
 for INIT_FILE in "${ALL_INIT_FILES[@]}"
 do
+    echo "Setting version in: ${INIT_FILE}"
+
     if [[ ! -e "${INIT_FILE}" ]]; then
         >&2 echo "ERROR: Version file ${INIT_FILE} does not exist."
         exit 1

--- a/actions/st2_prep_release_for_st2.sh
+++ b/actions/st2_prep_release_for_st2.sh
@@ -72,15 +72,15 @@ fi
 echo "Creating new branch ${BRANCH}..."
 git checkout -b ${BRANCH} origin/master
 
-files=(
+COMMON_INIT_FILES=(
     "st2common/st2common/__init__.py"
     "st2client/st2client/__init__.py"
 )
 
 # Add all the runners
-runner_init_files=($(find contrib/runners -maxdepth 3 -name __init__.py -not -path "*tests*" -not -path "*query*" -not -path "*callback*" -not -path "*functions*"))
+RUNNER_INIT_FILES=($(find contrib/runners -maxdepth 3 -name __init__.py -not -path "*tests*" -not -path "*query*" -not -path "*callback*" -not -path "*functions*"))
 
-init_files=("${files[@]}" "${runner_init_files[@]}")
+ALL_INIT_FILES=("${COMMON_INIT_FILES[@]}" "${RUNNER_INIT_FILES[@]}")
 
 for f in "${init_files[@]}"
 do

--- a/actions/st2_prep_release_for_st2.sh
+++ b/actions/st2_prep_release_for_st2.sh
@@ -77,7 +77,12 @@ files=(
     "st2client/st2client/__init__.py"
 )
 
-for f in "${files[@]}"
+# Add all the runners
+runner_init_files=($(find contrib/runners -maxdepth 3 -name __init__.py -not -path "*tests*" -not -path "*query*" -not -path "*callback*" -not -path "*functions*"))
+
+init_files=("${files[@]}" "${runner_init_files[@]}")
+
+for f in "${init_files[@]}"
 do
     if [[ ! -e "$f" ]]; then
         >&2 echo "ERROR: Version file ${f} does not exist."


### PR DESCRIPTION
This pull request updates release workflow to set `__version__` for all the runner packages during the release process.

This change is part of https://github.com/StackStorm/st2/pull/4239.

Right now this change is not backward compatible which means we need to decide how to handle backward compatibility for v2.8:

1. Leave this code as is and cherry pick https://github.com/StackStorm/st2/pull/4239 into v2.8 branch (should be fine)
2. Update the workflow so setting runner version is not fatal if runner package `__init__.py` file doesn't contain `__version__` string.

That's fine for v2.8, but I don't like it going forward (it could mask actual issues) - I prefer failing loudly where possible.