### PR TITLE
Fix docs build workflows

### DIFF
--- a/actions/workflows/bwc_docs.yaml
+++ b/actions/workflows/bwc_docs.yaml
@@ -29,15 +29,15 @@
         cmd: "cd /tmp/{{repodir}} && cat version.txt | cut -d '.' -f 1-2"
       publish:
         version: "{{version[build_server].stdout | replace('\n', '')}}"
-      on-success: "make_bwcdocs"
+      on-success: "make_ewcdocs"
       on-failure: "clean_repo"
     -
-      name: "make_bwcdocs"
+      name: "make_ewcdocs"
       ref: "core.remote"
       params:
         hosts: "{{build_server}}"
         timeout: 2000
-        cmd: 'cd {{repodir}} && sudo pip install --upgrade "virtualenv==15.1.0" && make bwcdocs'
+        cmd: 'cd {{repodir}} && sudo pip install --upgrade "virtualenv==15.1.0" && make ewcdocs'
       on-success: "s3cmd_docs"
       on-failure: "clean_repo"
     -

--- a/actions/workflows/bwc_docs.yaml
+++ b/actions/workflows/bwc_docs.yaml
@@ -37,7 +37,7 @@
       params:
         hosts: "{{build_server}}"
         timeout: 2000
-        cmd: 'cd {{repodir}} && sudo pip install --upgrade "virtualenv==15.1.0" && make ewcdocs'
+        cmd: 'cd {{repodir}} && sudo -H pip install --upgrade "virtualenv==15.1.0" && make ewcdocs'
       on-success: "s3cmd_docs"
       on-failure: "clean_repo"
     -

--- a/actions/workflows/st2_docs.yaml
+++ b/actions/workflows/st2_docs.yaml
@@ -45,7 +45,7 @@
       params:
         hosts: "{{build_server}}"
         repo: "{{repodir}}"
-        timeout: 1000
+        timeout: 1500
       on-success: "s3cmd_docs"
       on-failure: "clean_repo"
     -


### PR DESCRIPTION
In May I changed the st2docs Makefile & CircleCI to use `make ewcdocs`, not `make bwcdocs`. That worked for CI, but I missed that this part needed updating. We have not been updating ewc-docs.extremenetworks.com since May.

Also needed to increase `make docs` timeout, now that we are cloning & making Orchestra docs.