### PR TITLE
Fix API docs sync rule to use githubwebhook.github_event

### DIFF
--- a/rules/st2cd_slack_github_push_master.yaml
+++ b/rules/st2cd_slack_github_push_master.yaml
@@ -15,3 +15,4 @@
         ref: "slack.post_message"
         parameters:
             message: "```[GITHUB - {{trigger.body.repository.full_name}}: {{trigger.body.ref.split('/')[-1]}}]\n    PUSHER: {{trigger.body.pusher.name}}\n    MSG: {{trigger.body.head_commit.message}}```"
+            channel: "#thunderdome"

--- a/rules/sync_api_docs_on_st2_commits.yaml
+++ b/rules/sync_api_docs_on_st2_commits.yaml
@@ -5,7 +5,7 @@ pack: st2cd
 enabled: true
 
 trigger:
-    type: circle_ci.build_event
+    type: githubwebhook.github_event
 
 criteria:
     trigger.body.ref:
@@ -22,4 +22,4 @@ action:
       username: stackstorm
       branch: master
       build_parameters:
-          ST2_BRANCH: "{{ trigger.body.payload.ref.split('/')[2] }}"
+          ST2_BRANCH: "{{ trigger.body.ref.split('/')[2] }}"


### PR DESCRIPTION
There were a total of 3 problems that I fixed:

1. All st2 repo push events were sent to https://ci-webhooks.stackstorm.net/webhooks/build/events and those events were going to /dev/null. Lindsay thankfully reminded me about st2docs and I noticed st2docs sent all events to https://ci-webhooks.stackstorm.net/webhooks/github/events. The webhook sensor is designed to listen to webhooks/github/events only. 

2. The trigger for the rule was incorrectly set to circle_ci.build_event

3. Thanks to arma, the goof up in action parameters was fixed. 

Rule enforced and API documentation synced https://circleci.com/gh/StackStorm/st2apidocs/93

```
lakshmi@st2cicd027:~$ st2 rule-enforcement get 5b4fb6a0d62701362d527dea
+---------------------+------------------------------------+
| Property            | Value                              |
+---------------------+------------------------------------+
| id                  | 5b4fb6a0d62701362d527dea           |
| rule.ref            | st2cd.sync_api_docs_on_st2_commits |
| trigger_instance_id | 5b4fb69bd62701362d527ddc           |
| execution_id        | 5b4fb69fd62701362d527de9           |
| failure_reason      |                                    |
| enforced_at         | 2018-07-18T21:52:31.369396Z        |
+---------------------+------------------------------------+
lakshmi@st2cicd027:~$```