### PR TITLE
Update rules to correctly use v2.8.1 as the latest stable version

### DIFF
--- a/rules/st2_pkg_test_stable_rhel6.yaml
+++ b/rules/st2_pkg_test_stable_rhel6.yaml
@@ -21,4 +21,4 @@ action:
     distro: RHEL6
     pkg_env: production
     release: stable
-    version: "2.7.2"
+    version: "2.8.1"

--- a/rules/st2_pkg_test_stable_rhel6_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_rhel6_enterprise.yaml
@@ -21,6 +21,6 @@ action:
     distro: RHEL6
     pkg_env: production
     release: stable
-    version: "2.7.2"
+    version: "2.8.1"
     enterprise: true
     enterprise_key: "{{st2kv.system.enterprise_key_prd_stable}}"

--- a/rules/st2_pkg_test_stable_rhel7.yaml
+++ b/rules/st2_pkg_test_stable_rhel7.yaml
@@ -21,4 +21,4 @@ action:
     distro: RHEL7
     pkg_env: production
     release: stable
-    version: "2.7.2"
+    version: "2.8.1"

--- a/rules/st2_pkg_test_stable_rhel7_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_rhel7_enterprise.yaml
@@ -21,6 +21,6 @@ action:
     distro: RHEL7
     pkg_env: production
     release: stable
-    version: "2.7.2"
+    version: "2.8.1"
     enterprise: true
     enterprise_key: "{{st2kv.system.enterprise_key_prd_stable}}"

--- a/rules/st2_pkg_test_stable_u14.yaml
+++ b/rules/st2_pkg_test_stable_u14.yaml
@@ -21,4 +21,4 @@ action:
     distro: UBUNTU14
     pkg_env: production
     release: stable
-    version: "2.7.2"
+    version: "2.8.1"

--- a/rules/st2_pkg_test_stable_u14_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_u14_enterprise.yaml
@@ -21,6 +21,6 @@ action:
     distro: UBUNTU14
     pkg_env: production
     release: stable
-    version: "2.7.2"
+    version: "2.8.1"
     enterprise: true
     enterprise_key: "{{st2kv.system.enterprise_key_prd_stable}}"

--- a/rules/st2_pkg_test_stable_u16.yaml
+++ b/rules/st2_pkg_test_stable_u16.yaml
@@ -21,4 +21,4 @@ action:
     distro: UBUNTU16
     pkg_env: production
     release: stable
-    version: "2.7.2"
+    version: "2.8.1"

--- a/rules/st2_pkg_test_stable_u16_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_u16_enterprise.yaml
@@ -21,6 +21,6 @@ action:
     distro: UBUNTU16
     pkg_env: production
     release: stable
-    version: "2.7.2"
+    version: "2.8.1"
     enterprise: true
     enterprise_key: "{{st2kv.system.enterprise_key_prd_stable}}"


### PR DESCRIPTION
It looks like this step failed or similar during the release process (no time to dig in right now and executions are already gone).

Thanks to @m4dcoder for catching this.