### PR TITLE
Reduce opstown noise

### DIFF
--- a/actions/workflows/destroy_vm.yaml
+++ b/actions/workflows/destroy_vm.yaml
@@ -55,8 +55,9 @@ st2cd.destroy_vm:
                 - get_volumes: <% $.used_id %>
         deregister_monitor:
             action: sensu.client_delete client=<% $.hostname %>.<% $.dns_zone %>
-            on-error:
-                - notify_deregister_monitor_failure
+            # Do not alert on deregister failure until pysensu-ng can distinguish genuine error from already deleted monitor
+            #on-error:
+            #    - notify_deregister_monitor_failure
             on-complete:
                 - get_volumes
         get_volumes:
@@ -110,7 +111,7 @@ st2cd.destroy_vm:
         notify_success:
             action: slack.post_message
             input:
-                channel: "#opstown"
+                channel: "#thunderdome"
                 message: "[SUCCEEDED] <% $.hostname %> was destroyed"
 
         notify_multiple_instances_failure:

--- a/rules/st2cd_slack_decommission.yaml
+++ b/rules/st2cd_slack_decommission.yaml
@@ -11,6 +11,6 @@
     action:
         ref: "slack.post_message"
         parameters:
-            channel: "#opstown"
+            channel: "#thunderdome"
             message: "{% if trigger.status != 'succeeded' %}*{% endif %}[{{trigger.status.upper()}}]{% if trigger.status != 'succeeded' %}*{% endif %} {{trigger.parameters.hostname}} was {% if trigger.status != 'succeeded' %}*NOT* {% endif %}destroyed\n"
     pack: "st2cd"


### PR DESCRIPTION
Further reduction of #opstown noise. 

If/when https://github.com/sangoma/pysensu/pull/11 ever gets merged, we should update the sensu actions to better handle things when deleting a client returns a 404. It's not exactly an error - it means that check does not exist anymore, or was never created.