### PR TITLE
Remove notify_deregister tasks

### DIFF
--- a/actions/workflows/destroy_vm.yaml
+++ b/actions/workflows/destroy_vm.yaml
@@ -122,11 +122,11 @@ st2cd.destroy_vm:
             on-complete:
                 - fail
 
-        notify_deregister_monitor_failure:
-            action: slack.post_message
-            input:
-                channel: "#opstown"
-                message: "[FAILED] Unable to deregister monitoring for <% $.hostname %>"
+        # notify_deregister_monitor_failure:
+        #     action: slack.post_message
+        #     input:
+        #         channel: "#opstown"
+        #         message: "[FAILED] Unable to deregister monitoring for <% $.hostname %>"
 
         notify_destroy_instance_failure:
             action: slack.post_message

--- a/actions/workflows/destroy_vm.yaml
+++ b/actions/workflows/destroy_vm.yaml
@@ -55,9 +55,6 @@ st2cd.destroy_vm:
                 - get_volumes: <% $.used_id %>
         deregister_monitor:
             action: sensu.client_delete client=<% $.hostname %>.<% $.dns_zone %>
-            # Do not alert on deregister failure until pysensu-ng can distinguish genuine error from already deleted monitor
-            #on-error:
-            #    - notify_deregister_monitor_failure
             on-complete:
                 - get_volumes
         get_volumes:
@@ -121,12 +118,6 @@ st2cd.destroy_vm:
                 message: "[FAILED] More than one instance for <% $.hostname %> were identified"
             on-complete:
                 - fail
-
-        # notify_deregister_monitor_failure:
-        #     action: slack.post_message
-        #     input:
-        #         channel: "#opstown"
-        #         message: "[FAILED] Unable to deregister monitoring for <% $.hostname %>"
 
         notify_destroy_instance_failure:
             action: slack.post_message


### PR DESCRIPTION
Previously I commented out where we called the "deregister monitoring failed" task. That resulted in an orphan task that always ran. Not my intention. Now commented out the task itself too.