### PR TITLE
Remove deregister_monitor

### DIFF
--- a/actions/workflows/destroy_vm.yaml
+++ b/actions/workflows/destroy_vm.yaml
@@ -51,12 +51,7 @@ st2cd.destroy_vm:
 
         destroy:
             on-complete:
-                - deregister_monitor: <% $.used_dns %>
                 - get_volumes: <% $.used_id %>
-        deregister_monitor:
-            action: sensu.client_delete client=<% $.hostname %>.<% $.dns_zone %>
-            on-complete:
-                - get_volumes
         get_volumes:
             action: aws.ec2_get_instance_attribute
             input:


### PR DESCRIPTION
In the first `destroy_vm`, the `deregister_monitor` call fails. When `destroy_vm` is retried, `deregister_monitor` succeeds. However, during the retry, `delete_cname` fails because it was already removed. This results in the following error in slack.

```
[FAILED] st2-ent-pkg-stable-u14 was destroyed but CNAME was not deleted
```

This PR removes the call to deregister_monitor since it always fails.