### PR TITLE
Make dockerfile workflows idempotent, fix waits

### DIFF
--- a/actions/st2_chg_ver_for_st2_dockerfiles.sh
+++ b/actions/st2_chg_ver_for_st2_dockerfiles.sh
@@ -9,6 +9,7 @@ FORK=$1
 PROJECT=$2
 ST2_VERSION=$3
 BRANCH=$4
+LOCAL_REPO=$5
 
 GIT_REPO="git@github.com:${FORK}/${PROJECT}.git"
 CWD=`pwd`
@@ -56,10 +57,13 @@ if [[ $rc != 0 ]]; then
     cleanup
     exit $rc
 fi
-git add Makefile
 
-echo "Committing and pushing changes to Makefile"
-git commit -qm "Update version info for release - ${ST2_VERSION}"
-git push -u origin ${BRANCH} -q
+MODIFIED=`git status | grep modified || true`
+if [[ ! -z "${MODIFIED}" ]]; then
+    echo "Committing and pushing changes to Makefile"
+    git add -A
+    git commit -qm "Update version info for release - ${ST2_VERSION}"
+    git push -u origin ${BRANCH} -q
+fi
 
 cleanup

--- a/actions/st2_prep_dev_for_st2_dockerfiles.meta.yaml
+++ b/actions/st2_prep_dev_for_st2_dockerfiles.meta.yaml
@@ -25,3 +25,7 @@ parameters:
         description: Branch to update
         default: master
         position: 3
+    local_repo:
+        type: string
+        description: Location where to clone the repo. Programmatically determined if not provided.
+        position: 4

--- a/actions/st2_prep_dev_for_st2enterprise_dockerfiles.meta.yaml
+++ b/actions/st2_prep_dev_for_st2enterprise_dockerfiles.meta.yaml
@@ -25,3 +25,7 @@ parameters:
         description: Branch to update
         default: master
         position: 3
+    local_repo:
+        type: string
+        description: Location where to clone the repo. Programmatically determined if not provided.
+        position: 4

--- a/actions/st2_prep_release_for_st2enterprise_dockerfiles.meta.yaml
+++ b/actions/st2_prep_release_for_st2enterprise_dockerfiles.meta.yaml
@@ -25,3 +25,7 @@ parameters:
         description: Branch to update
         default: master
         position: 3
+    local_repo:
+        type: string
+        description: Location where to clone the repo. Programmatically determined if not provided.
+        position: 4

--- a/actions/wait_for_docker_image.meta.yaml
+++ b/actions/wait_for_docker_image.meta.yaml
@@ -21,12 +21,12 @@ parameters:
         required: true
         position: 2
     tries:
-        type: string
+        type: integer
         description: Check for image this many times
         required: true
         position: 3
-    delay:
-        type: string
+    check_delay:
+        type: integer
         description: Number of seconds to delay between each check
         required: true
         position: 4

--- a/actions/workflows/st2_finalize_release.yaml
+++ b/actions/workflows/st2_finalize_release.yaml
@@ -125,45 +125,7 @@ st2cd.st2_finalize_release:
                 hosts: <% $.host %>
                 cwd: <% $.cwd %>
             on-success:
-                - st2_dockerfiles_tag_release
-        st2_dockerfiles_tag_release:
-            action: st2cd.tag_release
-            input:
-                project: st2-dockerfiles
-                version: <% $.version %>
-                fork: <% $.fork %>
-                local_repo: <% 'st2_dockerfiles_' + $.local_repo_sfx %>
-                branch: master
-                hosts: <% $.host %>
-                cwd: <% $.cwd %>
-            on-success:
-                - wait_for_community_docker_image
-        wait_for_community_docker_image:
-            action: st2cd.wait_for_docker_image
-            input:
-                org: <% $.fork %>
-                image: st2web
-                version: <% $.version %>
-                tries: 15
-                check_delay: 60
-                hosts: <% $.host %>
-                cwd: <% $.cwd %>
-                timeout: 900
-            on-success:
-                - st2enterprise_dockerfiles_tag_release
-        st2enterprise_dockerfiles_tag_release:
-            action: st2cd.tag_release
-            input:
-                project: st2enterprise-dockerfiles
-                version: <% $.version %>
-                fork: <% $.fork %>
-                local_repo: <% 'st2enterprise_dockerfiles_' + $.local_repo_sfx %>
-                branch: master
-                hosts: <% $.host %>
-                cwd: <% $.cwd %>
-            on-success:
                 - get_utc_date
-
         get_utc_date:
             action: core.local
             input:
@@ -184,7 +146,6 @@ st2cd.st2_finalize_release:
                 cwd: <% $.cwd %>
             on-success:
                 - ship_api_docs
-
         ship_api_docs:
             action: circle_ci.run_build
             input:
@@ -193,6 +154,44 @@ st2cd.st2_finalize_release:
                 branch: master
                 build_parameters:
                     ST2_BRANCH: <% 'v' + $.major_minor_version %>
+            on-success:
+                - st2_dockerfiles_tag_release
+
+        st2_dockerfiles_tag_release:
+            action: st2cd.tag_release
+            input:
+                project: st2-dockerfiles
+                version: <% $.version %>
+                fork: <% $.fork %>
+                local_repo: <% 'st2_dockerfiles_' + $.local_repo_sfx %>
+                branch: master
+                hosts: <% $.host %>
+                cwd: <% $.cwd %>
+            on-success:
+                - wait_for_community_docker_image
+        wait_for_community_docker_image:
+            action: st2cd.wait_for_docker_image
+            input:
+                org: <% $.fork %>
+                image: st2web
+                version: <% $.version %>
+                tries: 10
+                check_delay: 60
+                hosts: <% $.host %>
+                cwd: <% $.cwd %>
+                timeout: 650
+            on-success:
+                - st2enterprise_dockerfiles_tag_release
+        st2enterprise_dockerfiles_tag_release:
+            action: st2cd.tag_release
+            input:
+                project: st2enterprise-dockerfiles
+                version: <% $.version %>
+                fork: <% $.fork %>
+                local_repo: <% 'st2enterprise_dockerfiles_' + $.local_repo_sfx %>
+                branch: master
+                hosts: <% $.host %>
+                cwd: <% $.cwd %>
 
         cleanup_on_failure:
             action: core.remote

--- a/actions/workflows/st2_finalize_release.yaml
+++ b/actions/workflows/st2_finalize_release.yaml
@@ -137,6 +137,19 @@ st2cd.st2_finalize_release:
                 hosts: <% $.host %>
                 cwd: <% $.cwd %>
             on-success:
+                - wait_for_community_docker_image
+        wait_for_community_docker_image:
+            action: st2cd.wait_for_docker_image
+            input:
+                org: <% $.fork %>
+                image: st2web
+                version: <% $.version %>
+                tries: 15
+                check_delay: 60
+                hosts: <% $.host %>
+                cwd: <% $.cwd %>
+                timeout: 900
+            on-success:
                 - st2enterprise_dockerfiles_tag_release
         st2enterprise_dockerfiles_tag_release:
             action: st2cd.tag_release

--- a/actions/workflows/st2_prep_dev.yaml
+++ b/actions/workflows/st2_prep_dev.yaml
@@ -113,19 +113,7 @@ st2cd.st2_prep_dev:
                 project: st2-dockerfiles
                 version: <% $.dev_version %>
                 fork: <% $.fork %>
-                local_repo: <% 'st2_' + $.local_repo_sfx %>
-                hosts: <% $.host %>
-                cwd: <% $.cwd %>
-            on-success:
-                - wait_for_community_docker_images
-        wait_for_community_docker_image:
-            action: st2cd.wait_for_docker_image
-            input:
-                org: <% $.fork %>
-                image: st2web
-                version: <% $.version %>
-                tries: 15
-                delay: 60
+                local_repo: <% 'st2dockerfiles_' + $.local_repo_sfx %>
                 hosts: <% $.host %>
                 cwd: <% $.cwd %>
             on-success:
@@ -136,7 +124,7 @@ st2cd.st2_prep_dev:
                 project: st2enterprise-dockerfiles
                 version: <% $.dev_version %>
                 fork: <% $.fork %>
-                local_repo: <% 'st2_' + $.local_repo_sfx %>
+                local_repo: <% 'st2enterprisedockerfiles_' + $.local_repo_sfx %>
                 hosts: <% $.host %>
                 cwd: <% $.cwd %>
 

--- a/actions/workflows/st2_prep_release.yaml
+++ b/actions/workflows/st2_prep_release.yaml
@@ -126,18 +126,6 @@ st2cd.st2_prep_release:
                 hosts: <% $.host %>
                 cwd: <% $.cwd %>
             on-success:
-                - wait_for_community_docker_images
-        wait_for_community_docker_image:
-            action: st2cd.wait_for_docker_image
-            input:
-                org: <% $.fork %>
-                image: st2web
-                version: <% $.version %>
-                tries: 15
-                delay: 60
-                hosts: <% $.host %>
-                cwd: <% $.cwd %>
-            on-success:
                 - prep_st2enterprise_dockerfiles
         prep_st2enterprise_dockerfiles:
             action: st2cd.st2_prep_release_for_st2enterprise_dockerfiles


### PR DESCRIPTION
If the local workspace already existed, then the `st2_chg_ver_for_st2_dockerfiles.sh` script failed. Fixed.

Also added `LOCAL_REPO` where missing.

Please carefully review to ensure the changes are implemented as desired.