### PR TITLE
Fix name of variable used at for loop in st2_prep_release_for_st2

### DIFF
--- a/actions/st2_prep_release_for_st2.sh
+++ b/actions/st2_prep_release_for_st2.sh
@@ -82,7 +82,7 @@ RUNNER_INIT_FILES=($(find contrib/runners -maxdepth 3 -name __init__.py -not -pa
 
 ALL_INIT_FILES=("${COMMON_INIT_FILES[@]}" "${RUNNER_INIT_FILES[@]}")
 
-for f in "${init_files[@]}"
+for f in "${ALL_INIT_FILES[@]}"
 do
     if [[ ! -e "$f" ]]; then
         >&2 echo "ERROR: Version file ${f} does not exist."


### PR DESCRIPTION
The variable used at the for loop has been renamed to ALL_INIT_FILES. Currently, the for loop is iterating over an empty list.