### PR TITLE
Surround version string with quotes

### DIFF
--- a/actions/workflows/bwc_docs.yaml
+++ b/actions/workflows/bwc_docs.yaml
@@ -26,7 +26,7 @@
       ref: "core.remote"
       params:
         hosts: "{{build_server}}"
-        cmd: "cd /tmp/{{repodir}} && cat version.txt | cut -d '.' -f 1-2"
+        cmd: "cd /tmp/{{repodir}} && echo $(echo -n '\"'; cat version.txt | cut -d '.' -f 1-2; echo '\"')"
       publish:
         version: "{{version[build_server].stdout | replace('\n', '')}}"
       on-success: "make_ewcdocs"

--- a/actions/workflows/st2_docs.yaml
+++ b/actions/workflows/st2_docs.yaml
@@ -26,7 +26,7 @@
       ref: "core.remote"
       params:
         hosts: "{{build_server}}"
-        cmd: "cd /tmp/{{repodir}} && cat version.txt | cut -d '.' -f 1-2"
+        cmd: "cd /tmp/{{repodir}} && echo $(echo -n '\"'; cat version.txt | cut -d '.' -f 1-2; echo '\"')"
       publish:
         version: "{{version[build_server].stdout | replace('\n', '')}}"
       on-success: "update_url"


### PR DESCRIPTION
Prevents ST2 from interpreting the result (`2.10`) as a float, which gets truncated to `2.1`.