### PR TITLE
Remove newline in version string

### DIFF
--- a/actions/workflows/bwc_docs.yaml
+++ b/actions/workflows/bwc_docs.yaml
@@ -26,7 +26,7 @@
       ref: "core.remote"
       params:
         hosts: "{{build_server}}"
-        cmd: "cd /tmp/{{repodir}} && echo $(echo -n '\"'; cat version.txt | cut -d '.' -f 1-2 | tr -d '\n'; echo '\"')"
+        cmd: "cd /tmp/{{repodir}} && echo $(echo -n '\"'; cat version.txt | cut -d '.' -f 1-2 | tr -d '\r\n'; echo '\"')"
       publish:
         version: "{{version[build_server].stdout | replace('\n', '')}}"
       on-success: "make_ewcdocs"

--- a/actions/workflows/bwc_docs.yaml
+++ b/actions/workflows/bwc_docs.yaml
@@ -26,7 +26,7 @@
       ref: "core.remote"
       params:
         hosts: "{{build_server}}"
-        cmd: "cd /tmp/{{repodir}} && echo $(echo -n '\"'; cat version.txt | cut -d '.' -f 1-2; echo '\"')"
+        cmd: "cd /tmp/{{repodir}} && echo $(echo -n '\"'; cat version.txt | cut -d '.' -f 1-2 | tr -d '\n'; echo '\"')"
       publish:
         version: "{{version[build_server].stdout | replace('\n', '')}}"
       on-success: "make_ewcdocs"

--- a/actions/workflows/st2_docs.yaml
+++ b/actions/workflows/st2_docs.yaml
@@ -26,7 +26,7 @@
       ref: "core.remote"
       params:
         hosts: "{{build_server}}"
-        cmd: "cd /tmp/{{repodir}} && echo $(echo -n '\"'; cat version.txt | cut -d '.' -f 1-2 | tr -d '\n'; echo '\"')"
+        cmd: "cd /tmp/{{repodir}} && echo $(echo -n '\"'; cat version.txt | cut -d '.' -f 1-2 | tr -d '\r\n'; echo '\"')"
       publish:
         version: "{{version[build_server].stdout | replace('\n', '')}}"
       on-success: "update_url"

--- a/actions/workflows/st2_docs.yaml
+++ b/actions/workflows/st2_docs.yaml
@@ -26,7 +26,7 @@
       ref: "core.remote"
       params:
         hosts: "{{build_server}}"
-        cmd: "cd /tmp/{{repodir}} && echo $(echo -n '\"'; cat version.txt | cut -d '.' -f 1-2; echo '\"')"
+        cmd: "cd /tmp/{{repodir}} && echo $(echo -n '\"'; cat version.txt | cut -d '.' -f 1-2 | tr -d '\n'; echo '\"')"
       publish:
         version: "{{version[build_server].stdout | replace('\n', '')}}"
       on-success: "update_url"


### PR DESCRIPTION
Removing new line so the version is parsed correctly. There should be no space before the trailing forward slash.

```
  version: /2.10 /
```

This PR will resolve the following `s3cmd_docs` error, which has prevented the docs for `2.10` (and other versions) from being installed or updated correctly:

```
    stderr: 'ERROR: Parameter problem: Destination S3 URI must end with ''/'' (ie must refer to a directory on the remote side).'
```