### PR TITLE
Set pack version attribute inside pack.yaml for bundled packs inside "st2cd.st2_chg_ver_for_st2" action

### DIFF
--- a/actions/st2_chg_ver_for_st2.sh
+++ b/actions/st2_chg_ver_for_st2.sh
@@ -98,10 +98,10 @@ if [ "${IS_DEV_VERSION}" = "false" ]; then
             exit 1
         fi
 
-        VERSION_STR_MATCH=`grep "^version\s+:\s+" ${PACK_METADATA_FILE} || true`
+        VERSION_STR_MATCH=`grep -Po "^version\s*:\s*${VERSION}" ${PACK_METADATA_FILE}`
         if [[ -z "${VERSION_STR_MATCH}" ]]; then
             echo "Setting version in ${PACK_METADATA_FILE} to ${VERSION}..."
-            sed -i -E "s/^version\s+:\s+(.*?)$/version: ${VERSION}/" ${PACK_METADATA_FILE}
+            sed -i -E "s/^version\s*:\s*(.*?)$/version: ${VERSION}/" ${PACK_METADATA_FILE}
 
             VERSION_STR_MATCH=`grep "${VERSION}" ${PACK_METADATA_FILE} || true`
             if [[ -z "${VERSION_STR_MATCH}" ]]; then


### PR DESCRIPTION
This pull request updates ``st2cd.st2_chg_ver_for_st2`` action so we also set ``version: <foo>`` attribute inside ``pack.yaml`` for all the bundled packs (core, linux, examples, etc.) to match the StackStorm version.

This will avoid confusion and will make it easier to see which version of pack content is installed on disk.

NOTE: We only do that for "stable" releases and version such as ``2.10.2``, ``3.0.0``, etc. We don't do it for a dev release because pack version attribute needs to be a valid semver string and Python dev version (e.g. ``2.10dev``) is not a valid semver string.

Related: https://github.com/StackStorm/st2/issues/4535