### PR TITLE
Fix patch release

### DIFF
--- a/actions/mistral_branch_candidate.yaml
+++ b/actions/mistral_branch_candidate.yaml
@@ -26,7 +26,7 @@ parameters:
     default: master
   repo_dir:
     type: string
-    default: /home/stanley
+    default: /mnt/repos
   requirements:
     type: string
     description: List of python dependencies from pip freeze.

--- a/actions/mistral_release_candidate.yaml
+++ b/actions/mistral_release_candidate.yaml
@@ -29,7 +29,7 @@ parameters:
     default: master
   mis_repo_dir:
     type: string
-    default: /home/stanley
+    default: /mnt/repos
   st2_repo_branch:
     type: string
     default: master

--- a/actions/workflows/bwc_stage_release_packages.yaml
+++ b/actions/workflows/bwc_stage_release_packages.yaml
@@ -16,7 +16,7 @@ tasks:
   init:
     action: core.local
     input:
-      cmd: echo <% ctx().version %> | cut -d "." -f1-2
+      cmd: echo -n '"'; echo -n <% ctx().version %> | cut -d "." -f1-2 | tr -d '\n'; echo -n '"'
     next:
       - when: <% succeeded() %>
         publish:

--- a/actions/workflows/mistral_branch_candidate.yaml
+++ b/actions/workflows/mistral_branch_candidate.yaml
@@ -54,6 +54,10 @@ tasks:
         do:
           - create_branch
       - when: <% failed() %>
+        publish:
+          - clone_paths: <% dict(mistral => result()[0].get(ctx().host).stdout,
+                                 mistralclient => result()[1].get(ctx().host).stdout,
+                                 st2mistral => result()[2].get(ctx().host).stdout) %>
         do:
           - remove_repos
           - fail

--- a/actions/workflows/mistral_branch_candidate.yaml
+++ b/actions/workflows/mistral_branch_candidate.yaml
@@ -15,10 +15,10 @@ tasks:
   init:
     action: core.noop
     next:
-      - when: <% ctx().host = null %>
+      - when: <% ctx().host = null or str(ctx().host).toLower() = "none" or str(ctx().host.toLower()) = "null" %>
         do:
           - get_host
-      - when: <% ctx().host != null %>
+      - when: <% ctx().host != null and str(ctx().host).toLower() != "none" and str(ctx().host.toLower()) != "null" %>
         do:
           - clone_repos
   get_host:

--- a/actions/workflows/mistral_branch_candidate.yaml
+++ b/actions/workflows/mistral_branch_candidate.yaml
@@ -32,6 +32,24 @@ tasks:
         publish:
           - host: <% result().result[0] %>
         do:
+          - create_repos_dir
+  create_repos_dir:
+    action: core.remote_sudo
+    input:
+      hosts: <% ctx().host %>
+      cmd: mkdir -p <% ctx().repo_dir %>
+    next:
+      - when: <% succeeded() %>
+        do:
+          - change_repos_dir_owner
+  change_repos_dir_owner:
+    action: core.remote_sudo
+    input:
+      hosts: <% ctx().host %>
+      cmd: chown stanley:stanley <% ctx().repo_dir %>
+    next:
+      - when: <% succeeded() %>
+        do:
           - clone_repos
   clone_repos:
     with:

--- a/actions/workflows/mistral_branch_candidate.yaml
+++ b/actions/workflows/mistral_branch_candidate.yaml
@@ -73,6 +73,10 @@ tasks:
     next:
       - do:
           - remove_repos
+      - when: <% failed() %>
+        do:
+          - fail
+
   remove_repos:
     with:
       items: repo in <% list(ctx().clone_paths.get(mistral),

--- a/actions/workflows/mistral_release_candidate.yaml
+++ b/actions/workflows/mistral_release_candidate.yaml
@@ -72,3 +72,6 @@ tasks:
       channel: <% item(channel) %>
       text: 'st2cd.mistral_release_candidate: FAILED'
       attachments: '[{"fallback": "[st2cd.mistral_release_candidate: FAILED]", "title": "[st2cd.mistral_release_candidate: FAILED]", "title_link": "<% ctx().webui_base_url %>/#/history/<% ctx(st2).action_execution_id %>/general", "text": "Error releasing candidate <% ctx().version %>.", "color": "#FF0000"}]'
+    next:
+      - do:
+          - fail

--- a/actions/workflows/mistral_release_candidate.yaml
+++ b/actions/workflows/mistral_release_candidate.yaml
@@ -29,8 +29,8 @@ tasks:
     next:
       - when: <% succeeded() %>
         publish:
-          - shas: <% result().shas %>
-          - deps: <% result().deps %>
+          - shas: <% result().output.shas %>
+          - deps: <% result().output.deps %>
         do:
           - branch
       - when: <% failed() %>


### PR DESCRIPTION
Ignore the branch name - this is to fix the patch release process.

All of these workflows were run to release 2.10.2.

This PR is a companion to StackStorm/st2ci#138 and StackStorm/mistral_dev#10.