### PR TITLE
Delete workroom test alias

### DIFF
--- a/aliases/workroom_test.yaml
+++ b/aliases/workroom_test.yaml
@@ -1,8 +1,0 @@
----
-name: "workroom_test"
-pack: "st2cd"
-action_ref: "st2cd.st2workroom_test"
-formats:
-  - "workroom ci {{branch}} on {{hostname}} {{build=chatops}}"
-  - "workroom ci on {{hostname}} {{build=chatops}}"
-description: "Test out st2workroom"


### PR DESCRIPTION
Refers to non-existent action, throws WARN on registration:
```
2019-04-04 19:09:39,016 INFO [-] =========================================================
2019-04-04 19:09:39,016 INFO [-] ############## Registering aliases ######################
2019-04-04 19:09:39,016 INFO [-] =========================================================
2019-04-04 19:09:39,209 WARNING [-] Action st2cd.st2workroom_test not found in DB. Did you forget to register the action?
2019-04-04 19:09:39,384 INFO [-] Registered 18 aliases.
2019-04-04 19:09:39,385 INFO [-] =========================================================
```