### PR TITLE
Add missing prep_st2docs task to st2_prep_dev workflow.

### DIFF
--- a/actions/workflows/st2_prep_dev.yaml
+++ b/actions/workflows/st2_prep_dev.yaml
@@ -69,6 +69,22 @@ tasks:
     next:
       - when: <% succeeded() %>
         do:
+          - prep_st2docs
+      - when: <% failed() %>
+        do:
+          - cleanup_on_failure
+  prep_st2docs:
+    action: st2cd.st2_prep_dev_for_st2docs
+    input:
+      project: st2docs
+      version: <% ctx().dev_version %>
+      fork: <% ctx().fork %>
+      local_repo: <% 'st2docs' + ctx().local_repo_sfx %>
+      hosts: <% ctx().host %>
+      cwd: <% ctx().cwd %>
+    next:
+      - when: <% succeeded() %>
+        do:
           - prep_st2web
       - when: <% failed() %>
         do:


### PR DESCRIPTION
Noticed this task was missing while doing the release.

It looks like it was removed (https://github.com/StackStorm/st2cd/pull/347/files#diff-342a6b3541e3f2f4ff8f96cb794b7ce3L66), but never added back during Orquesta migration.