### PR TITLE
Add a temporary workaround for issue inStackStorm/4649

### DIFF
--- a/actions/st2_chg_ver_for_st2.sh
+++ b/actions/st2_chg_ver_for_st2.sh
@@ -12,6 +12,14 @@ GIT_REPO="git@github.com:${FORK}/${PROJECT}.git"
 CWD=`pwd`
 PUSH=0
 
+# Temporary workaround until we fix "False" default value for boolean
+# See https://github.com/StackStorm/st2/issues/4649
+if [ "$#" -eq 5 ]; then
+    # UPDATE_MISTRAL and UPDATE_CHANGELOG not provided due to bug in StackStorm
+    UPDATE_MISTRAL="0"
+    UPDATE_CHANGELOG="0"
+fi
+
 
 # CHECK IF BRANCH EXISTS
 BRANCH_EXISTS=`git ls-remote --heads ${GIT_REPO} | grep refs/heads/${BRANCH} || true`


### PR DESCRIPTION
This is a temporary workaround for issue in https://github.com/StackStorm/st2/issues/4649.

This has been broken probably for ever, but we never noticed it since the error was not fatal and the execution itself succeeded (I randomly noticed it while viewing execution output).

That's the error which made me notice it:

```bash
/home/stanley/5cc3353aff4b7b49fbc77339/st2_chg_ver_for_st2.sh: line 133: [: st2_1556297017_663: integer expression expected
/home/stanley/5cc3353aff4b7b49fbc77339/st2_chg_ver_for_st2.sh: line 183: [: : integer expression expected
```