### PR TITLE
Remove documentation build steps which are not needed anymore

### DIFF
--- a/actions/st2_chg_ver_for_st2.sh
+++ b/actions/st2_chg_ver_for_st2.sh
@@ -12,6 +12,14 @@ GIT_REPO="git@github.com:${FORK}/${PROJECT}.git"
 CWD=`pwd`
 PUSH=0
 
+# Temporary workaround until we fix "False" default value for boolean
+# See https://github.com/StackStorm/st2/issues/4649
+if [ "$#" -eq 5 ]; then
+    # UPDATE_MISTRAL and UPDATE_CHANGELOG not provided due to bug in StackStorm
+    UPDATE_MISTRAL="0"
+    UPDATE_CHANGELOG="0"
+fi
+
 
 # CHECK IF BRANCH EXISTS
 BRANCH_EXISTS=`git ls-remote --heads ${GIT_REPO} | grep refs/heads/${BRANCH} || true`

--- a/actions/workflows/bwc_finalize_release.yaml
+++ b/actions/workflows/bwc_finalize_release.yaml
@@ -43,26 +43,9 @@ tasks:
   finalize:
     next:
       - do:
-          - make_ewc_docs_stable
-  make_ewc_docs_stable:
-    action: circle_ci.run_build
-    input:
-      branch: v<% ctx().major_minor_version %>
-      project: ipfabric-docs
-      username: StackStorm
-    next:
-      - when: <% succeeded() %>
-        do:
-          - make_ewc_docs_latest
-      - when: <% failed() %>
-        do:
-          - cleanup_on_failure
-  make_ewc_docs_latest:
-    action: circle_ci.run_build
-    input:
-      branch: master
-      project: ipfabric-docs
-      username: StackStorm
+          - noop
+  noop:
+    action: core.noop
     next:
       - when: <% failed() %>
         do:

--- a/actions/workflows/st2_finalize_release.yaml
+++ b/actions/workflows/st2_finalize_release.yaml
@@ -53,26 +53,6 @@ tasks:
     next:
       - when: <% succeeded() %>
         do:
-          - make_st2docs_stable
-  make_st2docs_stable:
-    action: circle_ci.run_build
-    input:
-      branch: v<% ctx().major_minor_version %>
-      project: st2docs
-      username: StackStorm
-    next:
-      - when: <% succeeded() %>
-        do:
-          - make_st2docs_latest
-  make_st2docs_latest:
-    action: circle_ci.run_build
-    input:
-      branch: master
-      project: st2docs
-      username: StackStorm
-    next:
-      - when: <% succeeded() %>
-        do:
           - st2_tag_release
   st2_tag_release:
     action: st2cd.tag_release


### PR DESCRIPTION
This pull request removes "trigger documentation build" workflow steps which are not needed anymore.

## Background, Context

During v3.0.0 release process, I noticed those tasks started failing.

The root cause for that was that we recently updated Circle CI config for our documentation repos so docs are now built and deployed on each commit / push to master and release version branch of those docs repos. To be able to do that, we utilize Circle CI workflows which contain two jobs (``build`` and ``deploy``).

Circle CI API doesn't support triggering whole workflow using the API so those st2cd workflow tasks broke.

It turns out though that now we don't really need those trigger docs build job tasks as part of our release process anymore - as part of our release process we push a commit to master and version branch and this commit now automatically triggers documentation build and deploy (for example https://circleci.com/gh/StackStorm/st2docs/1834).

So in the end, that's a "win win" - we are living the event driven "dream" and it simplifies our release workflows a tiny bit.

NOTE: For the time being we still need a task which triggers a build for ``st2apidocs`` repo because we don't push any commits during the release process to that repo, but we download latest openapi.yaml file as part of the Circle CI build - https://github.com/StackStorm/st2apidocs/blob/master/.circleci/config.yml.

In this case triggering a build via API still works because we only have a single job named ``build`` there - https://github.com/StackStorm/st2apidocs/blob/master/.circleci/config.yml#L3.

If we wanted to follow the same and consistent approach as we do for st2docs there, we would need to update our release process to directly commit latest ``openapi.yaml`` to master and version branch in that repo (perhaps not a bad thing to do in the future).