### PR TITLE
Turn on BATS tests

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -120,7 +120,7 @@ tasks:
       hosts: <% ctx().host_ip %>
       env: <% ctx().st2_cli_env %>
       cmd: "cd /tmp/st2tests && bats docs/*.bats"
-      timeout: 300
+      timeout: 1200
     next:
       - when: <% succeeded() %>
         do:
@@ -131,7 +131,7 @@ tasks:
       hosts: <% ctx().host_ip %>
       env: <% ctx().st2_cli_env %>
       cmd: "cd /tmp/st2tests && bats cli/*.bats"
-      timeout: 300
+      timeout: 1200
     next:
       - when: <% succeeded() %>
         do:
@@ -142,7 +142,7 @@ tasks:
       hosts: <% ctx().host_ip %>
       env: <% ctx().st2_cli_env %>
       cmd: "cd /tmp/st2tests && bats chatops/*.bats"
-      timeout: 300
+      timeout: 1200
   #   next:
   #     - when: <% succeeded() %>
   #       do:

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -110,39 +110,39 @@ tasks:
       windows_password: <% ctx().windows_password %>
       env: <% ctx().st2_cli_env %>
       protocol: <% ctx().protocol %>
-  #   next:
-  #     - when: <% succeeded() %>
-  #       do:
-  #         - docs_tests
-  # docs_tests:
-  #   action: core.remote
-  #   input:
-  #     hosts: <% ctx().host_ip %>
-  #     env: <% ctx().st2_cli_env %>
-  #     cmd: "cd /tmp/st2tests && bats docs/*.bats"
-  #     timeout: 300
-  #   next:
-  #     - when: <% succeeded() %>
-  #       do:
-  #         - cli_tests
-  # cli_tests:
-  #   action: core.remote
-  #   input:
-  #     hosts: <% ctx().host_ip %>
-  #     env: <% ctx().st2_cli_env %>
-  #     cmd: "cd /tmp/st2tests && bats cli/*.bats"
-  #     timeout: 300
-  #   next:
-  #     - when: <% succeeded() %>
-  #       do:
-  #         - chatops_tests
-  # chatops_tests:
-  #   action: core.remote
-  #   input:
-  #     hosts: <% ctx().host_ip %>
-  #     env: <% ctx().st2_cli_env %>
-  #     cmd: "cd /tmp/st2tests && bats chatops/*.bats"
-  #     timeout: 300
+    next:
+      - when: <% succeeded() %>
+        do:
+          - docs_tests
+  docs_tests:
+    action: core.remote
+    input:
+      hosts: <% ctx().host_ip %>
+      env: <% ctx().st2_cli_env %>
+      cmd: "cd /tmp/st2tests && bats docs/*.bats"
+      timeout: 300
+    next:
+      - when: <% succeeded() %>
+        do:
+          - cli_tests
+  cli_tests:
+    action: core.remote
+    input:
+      hosts: <% ctx().host_ip %>
+      env: <% ctx().st2_cli_env %>
+      cmd: "cd /tmp/st2tests && bats cli/*.bats"
+      timeout: 300
+    next:
+      - when: <% succeeded() %>
+        do:
+          - chatops_tests
+  chatops_tests:
+    action: core.remote
+    input:
+      hosts: <% ctx().host_ip %>
+      env: <% ctx().st2_cli_env %>
+      cmd: "cd /tmp/st2tests && bats chatops/*.bats"
+      timeout: 300
   #   next:
   #     - when: <% succeeded() %>
   #       do:
@@ -150,6 +150,7 @@ tasks:
   # chatops_e2e_tests:
   #   action: st2cd.st2_chatops_e2e_tests
   #   input:
+  #     host_ip: <% ctx().host_ip %>
   #     cwd: /tmp/st2tests
     next:
       - when: <% succeeded() and (ctx().enterprise) %>


### PR DESCRIPTION
I'm not turning on the ChatOps end-to-end tests just yet, but the BATS tests should pass now.