### PR TITLE
Docker/use dev version

### DIFF
--- a/actions/workflows/docker_prep_dev.yaml
+++ b/actions/workflows/docker_prep_dev.yaml
@@ -70,14 +70,14 @@ tasks:
   wait_for_community_docker_image:
     action: st2cd.wait_for_docker_image
     input:
-      org: <% ctx().org %>
+      org: <% ctx().org.toLower() %>
       image: st2web
       version: <% ctx().dev_version %>
-      tries: 10
+      tries: 13
       check_delay: 60
       hosts: <% ctx().host %>
       cwd: <% ctx().cwd %>
-      timeout: 650
+      timeout: 1000
     next:
       - when: <% succeeded() %>
         do:

--- a/actions/workflows/docker_prep_dev.yaml
+++ b/actions/workflows/docker_prep_dev.yaml
@@ -7,6 +7,7 @@ input:
   - host
   - cwd
 vars:
+  - dev_version: <% ctx().version.split('.')[0] + '.' + ctx().version.split('.')[1] + 'dev' %>
   - local_repo_sfx:
 tasks:
   init:
@@ -51,7 +52,7 @@ tasks:
     action: st2cd.docker_chg_ver
     input:
       project: st2-dockerfiles
-      version: <% ctx().version %>
+      version: <% ctx().dev_version %>
       org: <% ctx().org %>
       branch: master
       local_repo: <% 'st2_dockerfiles_' + ctx().local_repo_sfx %>
@@ -71,7 +72,7 @@ tasks:
     input:
       org: <% ctx().org %>
       image: st2web
-      version: <% ctx().version %>
+      version: <% ctx().dev_version %>
       tries: 10
       check_delay: 60
       hosts: <% ctx().host %>
@@ -90,7 +91,7 @@ tasks:
     action: st2cd.docker_chg_ver
     input:
       project: st2enterprise-dockerfiles
-      version: <% ctx().version %>
+      version: <% ctx().dev_version %>
       org: <% ctx().org %>
       branch: master
       local_repo: <% 'st2enterprise_dockerfiles_' + ctx().local_repo_sfx %>


### PR DESCRIPTION
During the `3.0.0` release process, `st2 run st2cd.docker_prep_dev version=3.1.0 -a` changed the `Makefile` in the `st2-dockerfiles` and `st2enterprise-dockerfiles` repos, incorrectly setting `ST2_VERSION` to `3.1.0` instead of `3.1dev`. This resulted in failed nightly builds with the following error:

```
E: Version '3.1.0-*' for 'st2' was not found
```

The change made in this PR has been tested and was used to successfully update the `ST2_VERSION` variable. The resulting images were then successfully pushed to docker hub (community) and docker.stackstorm.com (enterprise) by their respective CI.