### PR TITLE
Fix change version script files

### DIFF
--- a/actions/st2_chg_ver_for_st2.sh
+++ b/actions/st2_chg_ver_for_st2.sh
@@ -85,7 +85,6 @@ done
 # Set version attribute for all the bundled packs (core, linux, examples, etc.)
 BUNDLED_PACKS_METADATA_FILES=($(find contrib/ -mindepth 2 -maxdepth 2 -name pack.yaml))
 
-
 # Temporary disable fail on failure for grep step where failure is OK
 set +e
 
@@ -94,7 +93,6 @@ set +e
 IS_DEV_VERSION=$(echo ${VERSION} |grep -v "dev$")
 EXIT_CODE=$?
 
-set -e
 
 if [ ${EXIT_CODE} -eq 1 ]; then
     IS_DEV_VERSION=true
@@ -127,6 +125,9 @@ if [ "${IS_DEV_VERSION}" = "false" ]; then
 else
     echo "Skipping setting version attribute in pack.yaml files for dev version"
 fi
+
+# Re-enable fail on failure
+set -e
 
 MODIFIED=`git status | grep modified || true`
 if [[ ! -z "${MODIFIED}" ]]; then

--- a/actions/st2_prep_release_for_st2.sh
+++ b/actions/st2_prep_release_for_st2.sh
@@ -109,6 +109,9 @@ done
 # Set version attribute for all the bundled packs (core, linux, examples, etc.)
 BUNDLED_PACKS_METADATA_FILES=($(find contrib/ -mindepth 2 -maxdepth 2 -name pack.yaml))
 
+# Temporary disable fail on failure for grep step where failure is OK
+set +e
+
 # NOTE: We don't set dev versions because pack version needs to be a valid semver string
 # (e.g 1.2.3) and Python dev version is not a valid semver string (e.g 2.10dev)
 IS_DEV_VERSION=$(echo ${VERSION} |grep -v "dev$")
@@ -145,6 +148,9 @@ if [ "${IS_DEV_VERSION}" = "false" ]; then
 else
     echo "Skipping setting version attribute in pack.yaml files for dev version"
 fi
+
+# Re-enable fail on failure
+set -e
 
 MODIFIED=`git status | grep modified || true`
 if [[ ! -z "${MODIFIED}" ]]; then


### PR DESCRIPTION
I noticed during the release that the code doesn't work correctly - we need to disable fail on failure functions for steps where we rely on grep exiting with non-zero status code.