### PR TITLE
Use bats from my fork which includes per-test timing information

### DIFF
--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -35,7 +35,7 @@ if [[ -n "$RHTEST" ]]; then
     # Install from GitHub
     # RHEL 7+ has both bats and jq package, so we don't need to do this once we
     # drop RHEL 6 support
-    git clone https://github.com/bats-core/bats-core.git
+    git clone --branch add_per_test_timing_information --depth 1 https://github.com/Kami/bats-core.git
     (cd bats-core; sudo ./install.sh /usr/local)
 elif [[ -n "$DEBTEST" ]]; then
     DEBVERSION=`lsb_release --release | awk '{ print $2 }'`
@@ -49,7 +49,7 @@ elif [[ -n "$DEBTEST" ]]; then
     # Install from GitHub
     # Ubuntu 16.04 has both bats and jq packages, so we don't need to do this
     # once we drop Ubuntu 14.04 support
-    git clone https://github.com/bats-core/bats-core.git
+    git clone --branch add_per_test_timing_information --depth 1 https://github.com/Kami/bats-core.git
     (cd bats-core; sudo ./install.sh /usr/local)
 else
     echo "Unknown Operating System."


### PR DESCRIPTION
This pull request updates our code to use bats from my fork which adds per test timing information - https://github.com/bats-core/bats-core/pull/221

I'm all for upstream first and I will also try to get change finished and merged upstream (if they will accept it), but at the moment we don't have time to wait on that.

It could a while and we are running blind at the moment (as far as per-test function timing goes).