### PR TITLE
Decrease ttlMonitorSleepSecs MongoDB setting value for end to end tests

### DIFF
--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -7,7 +7,6 @@ BRANCH=`echo ${VERSION} | cut -d "." -f1-2`
 # Install OS specific pre-reqs (Better moved to puppet at some point.)
 DEBTEST=`lsb_release -a 2> /dev/null | grep Distributor | awk '{print $3}'`
 RHTEST=`cat /etc/redhat-release 2> /dev/null | sed -e "s~\(.*\)release.*~\1~g"`
-SUBTYPE=`lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}'`
 
 # Decrease interval for MongoDB TTL expire thread. By default it runs every 60 seconds which
 # means we would need to wait at least 60 seconds in our key expire end to end tests.
@@ -58,8 +57,6 @@ else
     echo "Unknown Operating System."
     exit 2
 fi
-
-sleep 2
 
 # Setup crypto key file
 ST2_CONF="/etc/st2/st2.conf"

--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -15,13 +15,6 @@ if [[ -n "$RHTEST" ]]; then
     if [[ "$RHVERSION" -ge 7 ]]; then
         sudo yum install -y jq
 
-        # Rabbit MQ on RHEL 7 needs to be able to resolve the hsort name to
-        # localhost, so we need to add it in to /etc/hosts
-        # The sed command should be idempotent.
-        if [[ "$RHVERSION" -eq 7 ]]; then
-            sudo sed -i.e2e.bak "s/\\(localhost4.localdomain4\\) \\([^[:space:]]*\\)\$/\\1 $(hostname | cut -d . -f 1) \\2/" /etc/hosts
-            sudo service rabbitmq-server restart
-        fi
     else
         # For RHEL/CentOS 6
         sudo yum install -y epel-release

--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -39,6 +39,7 @@ if [[ -n "$RHTEST" ]]; then
     (cd bats-core; sudo ./install.sh /usr/local)
 elif [[ -n "$DEBTEST" ]]; then
     DEBVERSION=`lsb_release --release | awk '{ print $2 }'`
+    SUBTYPE=`lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}'`
     echo "*** Detected Distro is ${DEBTEST} - ${DEBVERSION} ***"
     sudo apt-get -q -y install build-essential jq python-pip python-dev wget
     # Remove bats-core if it already exists (this happens when test workflows
@@ -52,7 +53,12 @@ elif [[ -n "$DEBTEST" ]]; then
     git clone --branch add_per_test_timing_information --depth 1 https://github.com/Kami/bats-core.git
     (cd bats-core; sudo ./install.sh /usr/local)
 
-    sudo service mongod restart
+    if [[ "$SUBTYPE" == 'xenial' || "${SUBTYPE}" == "bionic" ]]; then
+      sudo systemctl enable mongod
+      sudo systemctl start mongod
+    else
+      sudo service mongod restart
+  fi
 else
     echo "Unknown Operating System."
     exit 2


### PR DESCRIPTION
This pull request sets ``ttlMonitorSleepSecs`` MongoDB server value to 1 second for end to end tests.

By default MongoDB scans tables and expires items with TTL every 60 seconds. This is not ideal for out end to end tests which test expiry functionality because it means we need to sleep for at least 60 seconds.

This pull request decreases those value so we can speed tests up and make them faster by 60 seconds.