### PR TITLE
Fix enterprise tests

### DIFF
--- a/actions/st2_upgrade_to_enterprise.sh
+++ b/actions/st2_upgrade_to_enterprise.sh
@@ -151,10 +151,8 @@ enable_and_configure_rbac() {
   # Enable RBAC
   echo "Enabling rbac in st2.conf"
 
-  sudo cat /etc/st2/st2.conf
   sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
   sudo crudini --set /etc/st2/st2.conf rbac backend 'enterprise'
-  sudo cat /etc/st2/st2.conf
 
   # TODO: Move directory creation to package
   sudo mkdir -p /opt/stackstorm/rbac/assignments/

--- a/actions/st2_upgrade_to_enterprise.sh
+++ b/actions/st2_upgrade_to_enterprise.sh
@@ -140,6 +140,8 @@ CONF
 }
 
 enable_and_configure_rbac() {
+  echo "Enabling and configuring RBAC in st2.conf"
+
   if [[ ${DISTRO} = \UBUNTU* ]]; then
       sudo apt-get install -y crudini
   else
@@ -147,8 +149,12 @@ enable_and_configure_rbac() {
   fi
 
   # Enable RBAC
+  echo "Enabling rbac in st2.conf"
+
+  sudo cat /etc/st2/st2.conf
   sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
   sudo crudini --set /etc/st2/st2.conf rbac backend 'enterprise'
+  sudo cat /etc/st2/st2.conf
 
   # TODO: Move directory creation to package
   sudo mkdir -p /opt/stackstorm/rbac/assignments/

--- a/actions/workflows/st2_enterprise_tests.yaml
+++ b/actions/workflows/st2_enterprise_tests.yaml
@@ -17,7 +17,18 @@ tasks:
     action: core.remote_sudo
     input:
       hosts: <% ctx().host_ip %>
-      cmd: grep -zlP '\[rbac\]\senable\s?=\s?True\sbackend\s?=\s?enterprise' /etc/st2/st2.conf
+      # The following formats are all considered as valid
+      #
+      # [rbac]
+      # backend = enterprise
+      # enable = True
+      #
+      # [rbac]
+      # enable = True
+      # backend = enterprise
+      #
+      # TODO: Eventually use crudini in a custom shell script?
+      cmd: grep -zlP '\[rbac\]\senable\s?=\s?True\sbackend\s?=\s?enterprise' /etc/st2/st2.conf || grep -zlP '\[rbac\]\sbackend\s?=\s?enterprise\senable\s?=\s?True' /etc/st2/st2.conf
       timeout: 10
     next:
       - when: <% succeeded() %>
@@ -57,4 +68,15 @@ tasks:
     input:
       hosts: <% ctx().host_ip %>
       cmd: /opt/stackstorm/st2/bin/python -c "import st2auth_enterprise_ldap_backend"
+      timeout: 10
+    next:
+      - when: <% succeeded() %>
+        do:
+          - verify_enterprise_rbac_backend_is_installed
+  # NOTE: RBAC has become a standalone package in StackStorm v3.0.0
+  verify_enterprise_rbac_backend_is_installed:
+    action: core.remote_sudo
+    input:
+      hosts: <% ctx().host_ip %>
+      cmd: /opt/stackstorm/st2/bin/python -c "import st2rbac_enterprise_backend"
       timeout: 10


### PR DESCRIPTION
This pull request fixes enterprise tests. It updates "verify RBAC is enabled" check so it supports arbitrary order in the config file (eventually we should migrate that check to use crudini...).

In addition to that, it adds additional check which verifies rbac Python package is installed.