### PR TITLE
Update create_vm workflow to print out hostname and /etc/hosts content post reboot

### DIFF
--- a/actions/workflows/create_vm.yaml
+++ b/actions/workflows/create_vm.yaml
@@ -95,5 +95,5 @@
       ref: "core.remote_sudo"
       params:
         hosts: "{{ec2_instance_private_ip}}"
-        cmd: "cat /etc/hostname ; hostname"
+        cmd: "cat /etc/hostname ; echo ''; hostname ; echo ''; cat /etc/hosts"
   default: "get_subnet_id"

--- a/actions/workflows/create_vm.yaml
+++ b/actions/workflows/create_vm.yaml
@@ -88,4 +88,12 @@
         keyfile: "{{keyfile}}"
         ssh_timeout: 30
         retries: 10
+      on-success: "check_hostname_post_reboot"
+    -
+      # Verify hostname is preserved across reboot
+      name: "check_hostname_post_reboot"
+      ref: "core.remote_sudo"
+      params:
+        hosts: "{{ec2_instance_private_ip}}"
+        cmd: "cat /etc/hostname ; hostname"
   default: "get_subnet_id"

--- a/actions/workflows/create_vm_role.yaml
+++ b/actions/workflows/create_vm_role.yaml
@@ -186,6 +186,18 @@ tasks:
       ssh_timeout: 30
       retries: 10
     next:
+      - when: <% succeeded() %>
+        do:
+          - check_hostname_post_reboot
+      - when: <% failed() %>
+        do:
+          - destroy_vm_on_failure
+  check_hostname_post_reboot:
+    action: core.remote_sudo
+    input:
+      hosts: <% ctx().ec2_instance_private_ip %>
+      cmd: cat /etc/hostname ; hostname
+    next:
       - when: <% failed() %>
         do:
           - destroy_vm_on_failure

--- a/actions/workflows/create_vm_role.yaml
+++ b/actions/workflows/create_vm_role.yaml
@@ -196,7 +196,7 @@ tasks:
     action: core.remote_sudo
     input:
       hosts: <% ctx().ec2_instance_private_ip %>
-      cmd: cat /etc/hostname ; hostname
+      cmd: "cat /etc/hostname ; echo ''; hostname ; echo ''; cat /etc/hosts"
     next:
       - when: <% failed() %>
         do:


### PR DESCRIPTION
Small addition to our create_vm workflow so we print out current hostname and the contents of ``/etc/hosts`` file after we set the hostname and reboot the server.

This will help us debug various hostname related issues in the future.