### PR TITLE
Increase timeout of test_quickstart_key action

### DIFF
--- a/actions/workflows/st2_e2e_tests_test_quickstart.yaml
+++ b/actions/workflows/st2_e2e_tests_test_quickstart.yaml
@@ -29,6 +29,7 @@ tasks:
       hosts: <% ctx().host %>
       env: <% ctx().env %>
       cmd: st2 run tests.test_quickstart_key <% ctx().st2_cli_args %>
+      timeout: 90
   test_quickstart_rules:
     action: core.remote
     input:


### PR DESCRIPTION
Closes #401 

This PR Increases the timeout of test_quickstart_key action to 90s. Currently the default timeout of 60s is used which is causing the tests to timeout on RHEL 6 and RHEL 7, though the actions are successfully completed on the remote VM.