### PR TITLE
Fix EL6 e2e test build failing on virtualenv permissions

### DIFF
--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -136,7 +136,7 @@ sudo pip install --upgrade "virtualenv==15.1.0"
 
 # wheel==0.30.0 doesn't support python 2.6 (default on el6)
 if [[ "$RHVERSION" == 6 ]]; then
-    virtualenv --no-download venv -p /opt/stackstorm/st2/bin/python2.7
+    virtualenv --always-copy --no-download venv -p /opt/stackstorm/st2/bin/python2.7
 else
     virtualenv --no-download venv
 fi


### PR DESCRIPTION
EL6 e2e test builds started failing with the following error
```
Running virtualenv with interpreter /opt/stackstorm/st2/bin/python2.7
Using real prefix '/usr/share/python/st2python'
New python executable in /tmp/st2tests/venv/bin/python2.7
Also creating executable in /tmp/st2tests/venv/bin/python
Overwriting /tmp/st2tests/venv/lib/python2.7/distutils/__init__.py with new content
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/virtualenv.py", line 2328, in <module>
    main()
  File "/usr/lib/python2.6/site-packages/virtualenv.py", line 713, in main
    symlink=options.symlink)
  File "/usr/lib/python2.6/site-packages/virtualenv.py", line 927, in create_environment
    install_distutils(home_dir)
  File "/usr/lib/python2.6/site-packages/virtualenv.py", line 1489, in install_distutils
    writefile(os.path.join(distutils_path, '__init__.py'), DISTUTILS_INIT)
  File "/usr/lib/python2.6/site-packages/virtualenv.py", line 373, in writefile
    with open(dest, 'wb') as f:
IOError: [Errno 13] Permission denied: '/tmp/st2tests/venv/lib/python2.7/distutils/__init__.py'
```

After looking closer, `virtualenv` setup which is executed by normal user creates symlinks to python2.7 libs. Because those files are owned by root, attempt to overwrite `distutils/__init__.py` fails with permissions error.

Add `--always-copy` flag to virtualenv which copies files rather then symlinking and makes more sense here.