### PR TITLE
Add rules to run CI for stable u18 daily

### DIFF
--- a/actions/st2_prep_release_cd_rules.meta.yaml
+++ b/actions/st2_prep_release_cd_rules.meta.yaml
@@ -27,10 +27,10 @@
         position: 3
     oses:
         type: string
-        description: "Space seperated list of operating systems supported by st2 e.g. 'rhel6 rhel7 u14 u16'"
+        description: "Space seperated list of operating systems supported by st2 e.g. 'rhel6 rhel7 u14 u16 u18'"
         required: true
         position: 4
-        default: rhel6 rhel7 u14 u16
+        default: rhel6 rhel7 u14 u16 u18
     local_repo:
         type: string
         description: Location where to clone the repo. Programmatically determined if not provided.

--- a/actions/st2_prep_release_rules.meta.yaml
+++ b/actions/st2_prep_release_rules.meta.yaml
@@ -15,6 +15,6 @@ parameters:
     required: true
   oses:
     type: string
-    description: Space separated list of operating systems supported by st2 e.g. 'rhel6 rhel7 u14 u16'
+    description: Space separated list of operating systems supported by st2 e.g. 'rhel6 rhel7 u14 u16 u18'
     required: true
-    default: rhel6 rhel7 u14 u16
+    default: rhel6 rhel7 u14 u16 u18

--- a/rules/st2_pkg_test_stable_u18.yaml
+++ b/rules/st2_pkg_test_stable_u18.yaml
@@ -1,0 +1,25 @@
+---
+name: st2_pkg_test_stable_u18
+pack: st2cd
+description: Test stable packages
+enabled: true
+
+trigger:
+  type: core.st2.CronTimer
+  parameters:
+    timezone: US/Pacific
+    hour: 6
+    minute: 0
+    second: 0
+
+criteria: {}
+
+action:
+  ref: st2ci.st2_pkg_e2e_test
+  parameters:
+    hostname: st2-pkg-stable-u18
+    distro: UBUNTU18
+    pkg_env: production
+    release: stable
+    version: "3.1.0"
+    chatops: true

--- a/rules/st2_pkg_test_stable_u18_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_u18_enterprise.yaml
@@ -1,0 +1,27 @@
+---
+name: st2_pkg_test_stable_u18_enterprise
+pack: st2cd
+description: Test stable packages
+enabled: true
+
+trigger:
+  type: core.st2.CronTimer
+  parameters:
+    timezone: US/Pacific
+    hour: 7
+    minute: 0
+    second: 0
+
+criteria: {}
+
+action:
+  ref: st2ci.st2_pkg_e2e_test
+  parameters:
+    hostname: st2-ent-pkg-stable-u18
+    distro: UBUNTU18
+    pkg_env: production
+    release: stable
+    version: "3.1.0"
+    enterprise: true
+    enterprise_key: "{{st2kv.system.enterprise_key_prd_stable}}"
+    chatops: true


### PR DESCRIPTION
Add timer rules to run daily CIs for stable community and enterprise u18 packages. Add u18 as supported distro when updating these rules during release.