### PR TITLE
Update change version action to set version for all the Python package

### DIFF
--- a/actions/st2_chg_ver_for_st2.sh
+++ b/actions/st2_chg_ver_for_st2.sh
@@ -51,6 +51,13 @@ echo "Currently at directory `pwd`..."
 COMMON_INIT_FILES=(
     "st2common/st2common/__init__.py"
     "st2client/st2client/__init__.py"
+
+    "st2actions/st2actions/__init__.py"
+    "st2api/st2api/__init__.py"
+    "st2auth/st2auth/__init__.py"
+    "st2debug/st2debug/__init__.py"
+    "st2reactor/st2reactor/__init__.py"
+    "st2stream/st2stream/__init__.py"
 )
 
 # Add all the runners


### PR DESCRIPTION
This pull request updates change version action to set ``__version__`` attribute in ``__init__.py`` file for all the components Python packages.

Related change - https://github.com/StackStorm/st2/pull/4751.