### PR TITLE
Update Github references for ewc-installer repo

### DIFF
--- a/actions/bwc_prep_release_for_bwc_installer.meta.yaml
+++ b/actions/bwc_prep_release_for_bwc_installer.meta.yaml
@@ -1,14 +1,14 @@
 ---
 name: bwc_prep_release_for_bwc_installer
-description: Prepare the bwc-installer repo for release
+description: Prepare the ewc-installer repo for release
 enabled: true
 runner_type: remote-shell-script
 entry_point: bwc_prep_release_for_bwc_installer.sh
 parameters:
     project:
         type: string
-        description: Project name for bwc-installer
-        default: bwc-installer
+        description: Project name for ewc-installer
+        default: ewc-installer
         position: 0
     version:
         type: string
@@ -18,7 +18,7 @@ parameters:
     fork:
         type: string
         description: Fork to use
-        default: StackStorm
+        default: extremenetworks
         position: 2
     local_repo:
         type: string

--- a/actions/workflows/bwc_prep_release.yaml
+++ b/actions/workflows/bwc_prep_release.yaml
@@ -123,10 +123,10 @@ tasks:
   prep_bwc_installer:
     action: st2cd.bwc_prep_release_for_bwc_installer
     input:
-      project: bwc-installer
+      project: ewc-installer
       version: <% ctx().version %>
-      fork: <% ctx().fork %>
-      local_repo: <% 'bwc-installer_' + ctx().local_repo_sfx %>
+      fork: extremenetworks
+      local_repo: <% 'ewc-installer_' + ctx().local_repo_sfx %>
       hosts: <% ctx().host %>
       cwd: <% ctx().cwd %>
     next:


### PR DESCRIPTION
st2cd change for https://github.com/stackstorm/bwc-installer -> https://github.com/extremenetworks/ewc-installer repo migration and rename