### PR TITLE
Use unencrypted st2kv tokens for e2e tests

### DIFF
--- a/actions/st2_chatops_e2e_tests.meta.yaml
+++ b/actions/st2_chatops_e2e_tests.meta.yaml
@@ -20,7 +20,7 @@ parameters:
     immutable: true
   chatops_e2e_tests_slack_bot_api_token_u16:
     type: string
-    default: "{{ st2kv.system.chatops_e2e_tests_slack_bot_api_token_u16 | decrypt_kv }}"
+    default: "{{ st2kv.system.chatops_e2e_tests_slack_bot_api_token_u16 }}"
     secret: true
     immutable: true
   chatops_e2e_tests_slack_user_username_u16:
@@ -29,7 +29,7 @@ parameters:
     immutable: true
   chatops_e2e_tests_slack_user_api_token_u16:
     type: string
-    default: "{{ st2kv.system.chatops_e2e_tests_slack_user_api_token_u16 | decrypt_kv }}"
+    default: "{{ st2kv.system.chatops_e2e_tests_slack_user_api_token_u16 }}"
     secret: true
     immutable: true
 
@@ -43,7 +43,7 @@ parameters:
     immutable: true
   chatops_e2e_tests_slack_bot_api_token_u18:
     type: string
-    default: "{{ st2kv.system.chatops_e2e_tests_slack_bot_api_token_u18 | decrypt_kv }}"
+    default: "{{ st2kv.system.chatops_e2e_tests_slack_bot_api_token_u18 }}"
     secret: true
     immutable: true
   chatops_e2e_tests_slack_user_username_u18:
@@ -52,7 +52,7 @@ parameters:
     immutable: true
   chatops_e2e_tests_slack_user_api_token_u18:
     type: string
-    default: "{{ st2kv.system.chatops_e2e_tests_slack_user_api_token_u18 | decrypt_kv }}"
+    default: "{{ st2kv.system.chatops_e2e_tests_slack_user_api_token_u18 }}"
     secret: true
     immutable: true
 
@@ -66,7 +66,7 @@ parameters:
     immutable: true
   chatops_e2e_tests_slack_bot_api_token_el7:
     type: string
-    default: "{{ st2kv.system.chatops_e2e_tests_slack_bot_api_token_el7 | decrypt_kv }}"
+    default: "{{ st2kv.system.chatops_e2e_tests_slack_bot_api_token_el7 }}"
     secret: true
     immutable: true
   chatops_e2e_tests_slack_user_username_el7:
@@ -75,6 +75,6 @@ parameters:
     immutable: true
   chatops_e2e_tests_slack_user_api_token_el7:
     type: string
-    default: "{{ st2kv.system.chatops_e2e_tests_slack_user_api_token_el7 | decrypt_kv }}"
+    default: "{{ st2kv.system.chatops_e2e_tests_slack_user_api_token_el7 }}"
     secret: true
     immutable: true


### PR DESCRIPTION
Following https://github.com/StackStorm/ops-infra/pull/382