### PR TITLE
Increase timeout for CLI tests

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -145,7 +145,7 @@ tasks:
       env: <% ctx().st2_cli_env %>
       cmd: bats cli/*.bats
       cwd: /tmp/st2tests
-      timeout: 250
+      timeout: 400
     next:
       - when: <% succeeded() %>
         do:


### PR DESCRIPTION
CLI tests are timing out. This PR Increase timeout for CLI tests in
an attempt to resolve.

Fixes #419 