### PR TITLE
Increase timeout of cli tests

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -145,7 +145,7 @@ tasks:
       env: <% ctx().st2_cli_env %>
       cmd: bats cli/*.bats
       cwd: /tmp/st2tests
-      timeout: 400
+      timeout: 600
     next:
       - when: <% succeeded() %>
         do:


### PR DESCRIPTION
The run_cli_tests in st2_e2e_tests takes longer than 400 seconds to complete. Increase the timeout to 600 seconds to allow tests to complete.