### PR TITLE
Disable RHEL 8 nightlies until we actually have a stable release for RHEL 8

### DIFF
--- a/rules/st2_pkg_test_stable_rhel8.yaml
+++ b/rules/st2_pkg_test_stable_rhel8.yaml
@@ -2,7 +2,8 @@
 name: st2_pkg_test_stable_rhel8
 pack: st2cd
 description: Test stable packages
-enabled: true
+# TODO: Enable once we have release a stable version that supports RHEL 8
+enabled: false
 
 trigger:
   type: core.st2.CronTimer

--- a/rules/st2_pkg_test_stable_rhel8_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_rhel8_enterprise.yaml
@@ -2,7 +2,8 @@
 name: st2_pkg_test_stable_rhel8_enterprise
 pack: st2cd
 description: Test stable packages
-enabled: true
+# TODO: Enable once we have release a stable version that supports RHEL 8
+enabled: false
 
 trigger:
   type: core.st2.CronTimer


### PR DESCRIPTION
Because this currently just causes unnecessary nightly build failures.