### PR TITLE
Fix e2e tests for el6 and el7

### DIFF
--- a/actions/workflows/st2_chatops_e2e_tests.yaml
+++ b/actions/workflows/st2_chatops_e2e_tests.yaml
@@ -29,6 +29,10 @@ input:
   - chatops_e2e_tests_slack_user_username_el8
   - chatops_e2e_tests_slack_user_api_token_el8
 
+vars:
+  - ubuntu_version: null
+  - redhat_version: null
+
 tasks:
   switch_on_ubuntu_version:
     action: core.remote
@@ -37,7 +41,7 @@ tasks:
       cmd: "which lsb_release 1>/dev/null && { echo -n '\"'; lsb_release --release | awk '{ print $2 }' | tr -d '\\n'; echo '\"'; } || exit 1"
     next:
       - publish:
-          - ubuntu_version: <% result().get(ctx().host_ip).stdout %>
+          - ubuntu_version: <% succeeded() and result().get(ctx().host_ip).stdout %>
         do:
           - log_ubuntu_version
       - when: <% succeeded() and result().get(ctx().host_ip).stdout = '16.04' %>
@@ -50,16 +54,17 @@ tasks:
           - websocket:
         do:
           - run_with_slack_u18
-      - when: <% failed() or (succeeded() and not ["16.04", "18.04"].contains(result().get(ctx().host_ip).stdout)) %>
-        publish:
-          - ubuntu_version: <% result().get(ctx().host_ip).stdout %>
+      - when: <% succeeded() and not ["16.04", "18.04"].contains(result().get(ctx().host_ip).stdout) %>
+        do:
+          - switch_on_redhat_version
+      - when: <% failed() %>
         do:
           - switch_on_redhat_version
 
   log_ubuntu_version:
     action: core.echo
     input:
-      message: <% ctx().ubuntu_version %>
+      message: <% str(ctx().ubuntu_version) %>
 
   switch_on_redhat_version:
     action: core.remote
@@ -68,7 +73,7 @@ tasks:
       cmd: "echo -n '\"'; [[ -e /etc/redhat-release ]] && cat /etc/redhat-release 2>/dev/null | sed -r 's/^[a-zA-Z ]*([0-9]){1,}\\..*$/\\1/' | tr -d '\\n'; echo '\"'"
     next:
       - publish:
-          - redhat_version: <% result().get(ctx().host_ip).stdout %>
+          - redhat_version: <% succeeded() and result().get(ctx().host_ip).stdout %>
         do:
           - log_redhat_version
       - when: <% succeeded() and result().get(ctx().host_ip).stdout = '7' %>
@@ -81,16 +86,17 @@ tasks:
           - websocket: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         do:
           - run_with_slack_el8
-      - when: <% failed() or (succeeded() and not ["7"].contains(result().get(ctx().host_ip).stdout) and not ["8"].contains(result().get(ctx().host_ip).stdout)) %>
-        publish:
-          - redhat_version: <% result().get(ctx().host_ip).stdout %>
+      - when: <% succeeded() and not ["7"].contains(result().get(ctx().host_ip).stdout) and not ["8"].contains(result().get(ctx().host_ip).stdout) %>
+        do:
+          - log_skipping
+      - when: <% failed() %>
         do:
           - log_skipping
 
   log_redhat_version:
     action: core.echo
     input:
-      message: <% ctx().redhat_version %>
+      message: <% str(ctx().redhat_version) %>
 
   log_skipping:
     action: core.echo


### PR DESCRIPTION
In the e2e setup script, RHEL8 introduced install of python-pip3 but removed python-pip for el6 and el7. Fixed the workflow for the chatops e2e tests on various syntax and definition errors.