### PR TITLE
Use st2tests branch

### DIFF
--- a/actions/setup_e2e_tests.meta.yaml
+++ b/actions/setup_e2e_tests.meta.yaml
@@ -8,7 +8,9 @@ parameters:
   version:
     type: string
     default: "master"
-    description: Version used for the release. Should include the patch e.g. 0.1.0
+    description: >
+      Branch name or version string used for the release. If a version string,
+      it should include the patch release, e.g. 0.1.0
     position: 0
   sudo:
     immutable: true

--- a/actions/st2_e2e_tests.meta.yaml
+++ b/actions/st2_e2e_tests.meta.yaml
@@ -38,9 +38,9 @@ parameters:
     type: string
     secret: true
     description: Password to authenticate to the Windows server
-  version:
+  st2tests_version:
     type: string
-    description: Version used for the release. Should include the patch e.g. 0.1.0
+    description: Branch or version string used for the release. Should include the patch e.g. 0.1.0
   enterprise:
     type: boolean
     default: false

--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -11,7 +11,7 @@ input:
   - windows_host_fqdn
   - windows_username
   - windows_password
-  - version
+  - st2tests_version
   - enterprise
   - chatops
 tasks:
@@ -44,7 +44,7 @@ tasks:
     input:
       hosts: <% ctx().host_ip %>
       env: <% ctx().st2_cli_env %>
-      version: <% ctx().version %>
+      version: <% ctx().st2tests_version %>
       timeout: 220
     next:
       - when: <% succeeded() %>


### PR DESCRIPTION
The CI/CD process has previously only been able to clone from two branches of the StackStorm/st2tests repository: `master` and a version tag.

That makes it really difficult to test changes to st2tests, like StackStorm/st2tests#185. That means that I would have to merge that into `master` and rerun the CI/CD workflows to test with the `master` branch of st2tests. And if things broke, I would have to do the exact same thing again.

Instead of doing that, we should explicitly expose the branch of st2tests that will be cloned. This allows us to manually test out our st2tests changes against the current `master` branch of ST2 _before_ we merge those changes into st2tests `master`.

This should hopefully drive better software practices, as one more piece of the CI/CD system can be tested in isolation to the other pieces.

A corresponding PR is incoming for st2ci.

And one more thing: this change also enables us to add CI to the st2tests repository in the future, by adding a rule to run this with the st2tests PR branch and configuring that in GitHub.