### PR TITLE
Fix YAQL comparison operators for distro check

### DIFF
--- a/actions/workflows/st2_e2e_tests_test_inquiry.yaml
+++ b/actions/workflows/st2_e2e_tests_test_inquiry.yaml
@@ -28,11 +28,11 @@ tasks:
   check_if_mistral_is_available:
     action: core.noop
     next:
-      - when: <% succeeded() and ('u18' in ctx().host_fqdn.toLower() or 'rhel8' = ctx().host_fqdn.toLower() or 'centos8' = ctx().host_fqdn.toLower()) %>
+      - when: <% succeeded() and ('u18' in ctx().host_fqdn.toLower() or 'rhel8' in ctx().host_fqdn.toLower() or 'centos8' in ctx().host_fqdn.toLower()) %>
         do:
           # Mistral is not available on Ubuntu Bionic or RHEL8, so skip Mistral tests
           - noop
-      - when: <% succeeded() and (not 'u18' in ctx().host_fqdn.toLower()) and 'rhel8' != ctx().host_fqdn.toLower() and 'centos8' != ctx().host_fqdn.toLower() %>
+      - when: <% succeeded() and (not 'u18' in ctx().host_fqdn.toLower()) and (not 'rhel8' in ctx().host_fqdn.toLower()) and (not 'centos8' in ctx().host_fqdn.toLower()) %>
         do:
           - test_inquiry_mistral
   test_inquiry_mistral:


### PR DESCRIPTION
Fixes operators when checking Linux distribution for Mistral support. I messed this up when I added RHEL 8 support to this workflow.

Verified this works by installing this branch on st2cicd and manually rerunning a previously failed `st2ci.st2_pkg_e2e_test` workflow with `distro: RHEL8`.