### PR TITLE
Rely on a newer 'slack.chat.postMessage' instead of using old 'slack.post_message'

### DIFF
--- a/actions/workflows/cleanup_volumes.yaml
+++ b/actions/workflows/cleanup_volumes.yaml
@@ -40,15 +40,15 @@ tasks:
         do:
           - notify_failure
   notify_success:
-    action: slack.post_message
+    action: slack.chat.postMessage
     input:
       channel: <% ctx().notify_channel %>
-      message: '[SUCCEEDED] Unused volumes older than <% ctx().age %> seconds are deleted'
+      text: '[SUCCEEDED] Unused volumes older than <% ctx().age %> seconds are deleted'
   notify_failure:
-    action: slack.post_message
+    action: slack.chat.postMessage
     input:
       channel: <% ctx().notify_channel %>
-      message: '[FAILED] Unable to delete unused volumes'
+      text: '[FAILED] Unable to delete unused volumes'
     next:
       - do:
           - fail

--- a/actions/workflows/destroy_vm.yaml
+++ b/actions/workflows/destroy_vm.yaml
@@ -147,40 +147,40 @@ tasks:
           - delete_volumes
 
   notify_success:
-    action: slack.post_message
+    action: slack.chat.postMessage
     input:
       channel: <% ctx().notify_channel %>
-      message: '[SUCCEEDED] <% ctx().hostname %> was destroyed'
+      text: '[SUCCEEDED] <% ctx().hostname %> was destroyed'
 
   notify_multiple_instances_failure:
-    action: slack.post_message
+    action: slack.chat.postMessage
     input:
       channel: <% ctx().notify_failure_channel %>
-      message: '[FAILED] More than one instance for <% ctx().hostname %> were identified'
+      text: '[FAILED] More than one instance for <% ctx().hostname %> were identified'
     next:
       - do:
           - fail
 
   notify_destroy_instance_failure:
-    action: slack.post_message
+    action: slack.chat.postMessage
     input:
       channel: <% ctx().notify_failure_channel %>
-      message: '[FAILED] <% ctx().hostname %> was not destroyed'
+      text: '[FAILED] <% ctx().hostname %> was not destroyed'
     next:
       - do:
           - fail
 
   notify_delete_cname_failure:
-    action: slack.post_message
+    action: slack.chat.postMessage
     input:
       channel: <% ctx().notify_failure_channel %>
-      message: '[FAILED] <% ctx().hostname %> was destroyed but CNAME was not deleted'
+      text: '[FAILED] <% ctx().hostname %> was destroyed but CNAME was not deleted'
 
   notify_delete_volumes_failure:
-    action: slack.post_message
+    action: slack.chat.postMessage
     input:
       channel: <% ctx().notify_failure_channel %>
-      message: '[FAILED] <% ctx().hostname %> was destroyed but volumes were not deleted'
+      text: '[FAILED] <% ctx().hostname %> was destroyed but volumes were not deleted'
     next:
       - do:
           - fail

--- a/actions/workflows/st2_web_rollback.yaml
+++ b/actions/workflows/st2_web_rollback.yaml
@@ -62,15 +62,15 @@
       on-failure: "slack_failure"
     -
       name: "slack_success"
-      ref: "slack.post_message"
+      ref: "slack.chat.postMessage"
       params:
         channel: "#thunderdome"
-        message: "```[st2web rollback]\n STATUS: SUCCESS\n HOSTNAME: {{hostname}}\n CURRENT_WEB: {{previous[hostname].stdout}}\n URL: http://{{hostname}}:3000```"
+        text: "```[st2web rollback]\n STATUS: SUCCESS\n HOSTNAME: {{hostname}}\n CURRENT_WEB: {{previous[hostname].stdout}}\n URL: http://{{hostname}}:3000```"
     -
       name: "slack_failure"
-      ref: "slack.post_message"
+      ref: "slack.chat.postMessage"
       params:
         channel: "#thunderdome"
-        message: "```[st2web rollback]\n STATUS: FAILURE\n HOSTNAME: {{hostname}}\n ```"
+        text: "```[st2web rollback]\n STATUS: FAILURE\n HOSTNAME: {{hostname}}\n ```"
 
   default: "stop_st2web"

--- a/rules/slack_notify.yaml
+++ b/rules/slack_notify.yaml
@@ -11,7 +11,7 @@ criteria:
     pattern: "slack"
     type: "equals"
 action:
-  ref: slack.post_message
+  ref: slack.chat.postMessage
   parameters:
     channel: "#thunderdome"
-    message: "{{trigger.execution_id}}: {{trigger.message}}"
+    text: "{{trigger.execution_id}}: {{trigger.message}}"

--- a/rules/st2cd_slack_decommission.yaml
+++ b/rules/st2cd_slack_decommission.yaml
@@ -9,8 +9,8 @@
             pattern: "st2cd\\.destroy_vm"
             type: "matchregex"
     action:
-        ref: "slack.post_message"
+        ref: "slack.chat.postMessage"
         parameters:
             channel: "#thunderdome"
-            message: "{% if trigger.status != 'succeeded' %}*{% endif %}[{{trigger.status.upper()}}]{% if trigger.status != 'succeeded' %}*{% endif %} {{trigger.parameters.hostname}} was {% if trigger.status != 'succeeded' %}*NOT* {% endif %}destroyed\n"
+            text: "{% if trigger.status != 'succeeded' %}*{% endif %}[{{trigger.status.upper()}}]{% if trigger.status != 'succeeded' %}*{% endif %} {{trigger.parameters.hostname}} was {% if trigger.status != 'succeeded' %}*NOT* {% endif %}destroyed\n"
     pack: "st2cd"

--- a/rules/st2cd_slack_e2e_test.yaml
+++ b/rules/st2cd_slack_e2e_test.yaml
@@ -9,8 +9,8 @@
             pattern: "st2cd.e2e_tests"
             type: "equals"
     action:
-        ref: "slack.post_message"
+        ref: "slack.chat.postMessage"
         parameters:
             channel: "{% if trigger.status == 'succeeded' %}#thunderdome{% else %}#stackstorm{% endif %}"
-            message: "{% if trigger.status != 'succeeded' %}channel\n{% endif %}```[{{trigger.action_name}} - {{trigger.parameters.environment}}: {{trigger.status.upper()}}]\n    HOST: {{trigger.parameters.hostname}}\n    BRANCH: {{trigger.parameters.branch}}\n    SHA: {{trigger.parameters.revision}}\n    BUILD: {{trigger.parameters.build}}```"
+            text: "{% if trigger.status != 'succeeded' %}channel\n{% endif %}```[{{trigger.action_name}} - {{trigger.parameters.environment}}: {{trigger.status.upper()}}]\n    HOST: {{trigger.parameters.hostname}}\n    BRANCH: {{trigger.parameters.branch}}\n    SHA: {{trigger.parameters.revision}}\n    BUILD: {{trigger.parameters.build}}```"
     pack: "st2cd"

--- a/rules/st2cd_slack_github_push_master.yaml
+++ b/rules/st2cd_slack_github_push_master.yaml
@@ -13,7 +13,7 @@
             pattern: "StackStorm/st2"
             type: "equals"
     action:
-        ref: "slack.post_message"
+        ref: "slack.chat.postMessage"
         parameters:
-            message: "```[GITHUB - {{trigger.body.repository.full_name}}: {{trigger.body.ref.split('/')[-1]}}]\n    PUSHER: {{trigger.body.pusher.name}}\n    MSG: {{trigger.body.head_commit.message}}```"
+            text: "```[GITHUB - {{trigger.body.repository.full_name}}: {{trigger.body.ref.split('/')[-1]}}]\n    PUSHER: {{trigger.body.pusher.name}}\n    MSG: {{trigger.body.head_commit.message}}```"
             channel: "#thunderdome"

--- a/rules/st2cd_slack_pkg_rhel6.yaml
+++ b/rules/st2cd_slack_pkg_rhel6.yaml
@@ -9,8 +9,8 @@
             pattern: "st2cd.st2_pkg_rhel6"
             type: "equals"
     action:
-        ref: "slack.post_message"
+        ref: "slack.chat.postMessage"
         parameters:
             channel: "{% if trigger.status == 'succeeded' %}#thunderdome{% else %}#stackstorm{% endif %}"
-            message: "{% if trigger.status != 'succeeded' %}<!channel>\n{% endif %}```[{{trigger.action_name}}: {{trigger.status.upper()}}]\n    BUILD: {{trigger.result.get_current_build.result|trim}}\n    BUILD_HOST: {{trigger.parameters.build_server}}\n    BRANCH: {{trigger.parameters.branch}}\n    SHA: {{trigger.parameters.revision}}\n    BUILD: {{trigger.parameters.build}}```"
+            text: "{% if trigger.status != 'succeeded' %}<!channel>\n{% endif %}```[{{trigger.action_name}}: {{trigger.status.upper()}}]\n    BUILD: {{trigger.result.get_current_build.result|trim}}\n    BUILD_HOST: {{trigger.parameters.build_server}}\n    BRANCH: {{trigger.parameters.branch}}\n    SHA: {{trigger.parameters.revision}}\n    BUILD: {{trigger.parameters.build}}```"
     pack: "st2cd"

--- a/rules/st2cd_slack_pkg_ubuntu16.yaml
+++ b/rules/st2cd_slack_pkg_ubuntu16.yaml
@@ -9,8 +9,8 @@
             pattern: "st2cd.st2_pkg_ubuntu16"
             type: "equals"
     action:
-        ref: "slack.post_message"
+        ref: "slack.chat.postMessage"
         parameters:
             channel: "{% if trigger.status == 'succeeded' %}#thunderdome{% else %}#stackstorm{% endif %}"
-            message: "{% if trigger.status != 'succeeded' %}channel\n{% endif %}```[{{trigger.action_name}} - {{trigger.parameters.environment}}: {{trigger.status.upper()}}]\n    BRANCH: {{trigger.parameters.branch}}\n    SHA: {{trigger.parameters.revision}}\n    BUILD: {{trigger.parameters.build}}```"
+            text: "{% if trigger.status != 'succeeded' %}channel\n{% endif %}```[{{trigger.action_name}} - {{trigger.parameters.environment}}: {{trigger.status.upper()}}]\n    BRANCH: {{trigger.parameters.branch}}\n    SHA: {{trigger.parameters.revision}}\n    BUILD: {{trigger.parameters.build}}```"
     pack: "st2cd"

--- a/rules/st2cd_slack_provision.yaml
+++ b/rules/st2cd_slack_provision.yaml
@@ -9,8 +9,8 @@
             pattern: "st2cd.create_vm_role"
             type: "equals"
     action:
-        ref: "slack.post_message"
+        ref: "slack.chat.postMessage"
         parameters:
             channel: "#opstown"
-            message: "{% if trigger.status != 'succeeded' %}*{% endif %}[{{trigger.status.upper()}}]{% if trigger.status != 'succeeded' %}*{% endif %} {{trigger.parameters.hostname}} was {% if trigger.status != 'succeeded' %}*NOT* {% endif %} created with role {{trigger.parameters.role}} in {{trigger.parameters.environment}}"
+            text: "{% if trigger.status != 'succeeded' %}*{% endif %}[{{trigger.status.upper()}}]{% if trigger.status != 'succeeded' %}*{% endif %} {{trigger.parameters.hostname}} was {% if trigger.status != 'succeeded' %}*NOT* {% endif %} created with role {{trigger.parameters.role}} in {{trigger.parameters.environment}}"
     pack: "st2cd"

--- a/rules/st2cd_slack_pytests.yaml
+++ b/rules/st2cd_slack_pytests.yaml
@@ -9,8 +9,8 @@
             pattern: "st2cd.pytests"
             type: "equals"
     action:
-        ref: "slack.post_message"
+        ref: "slack.chat.postMessage"
         parameters:
             channel: "{% if trigger.status == 'succeeded' %}#thunderdome{% else %}#stackstorm{% endif %}"
-            message: "{% if trigger.status != 'succeeded' %}channel\n{% endif %}```[{{trigger.action_name}}: {{trigger.status.upper()}}]\n    BRANCH: {{trigger.parameters.branch}}\n    SHA: {{trigger.parameters.revision}}\n    BUILD: {{trigger.result.tasks[1].result.result.value}}```"
+            text: "{% if trigger.status != 'succeeded' %}channel\n{% endif %}```[{{trigger.action_name}}: {{trigger.status.upper()}}]\n    BRANCH: {{trigger.parameters.branch}}\n    SHA: {{trigger.parameters.revision}}\n    BUILD: {{trigger.result.tasks[1].result.result.value}}```"
     pack: "st2cd"

--- a/rules/st2cd_slack_upgrade_ubuntu16.yaml
+++ b/rules/st2cd_slack_upgrade_ubuntu16.yaml
@@ -12,7 +12,7 @@
             pattern: "staging"
             type: "equals"
     action:
-        ref: "slack.post_message"
+        ref: "slack.chat.postMessage"
         parameters:
             channel: "{% if trigger.status == 'succeeded' %}#thunderdome{% else %}#stackstorm{% endif %}"
-            message: "{% if trigger.status != 'succeeded' %}channel\n{% endif %}```[{{trigger.action_name}} - {{trigger.parameters.environment}}: {{trigger.status.upper()}}]\n    HOST: {{trigger.parameters.hostname}}\n    BRANCH: {{trigger.parameters.branch}}\n    SHA: {{trigger.parameters.revision}}\n    BUILD: {{trigger.parameters.build}}```"
+            text: "{% if trigger.status != 'succeeded' %}channel\n{% endif %}```[{{trigger.action_name}} - {{trigger.parameters.environment}}: {{trigger.status.upper()}}]\n    HOST: {{trigger.parameters.hostname}}\n    BRANCH: {{trigger.parameters.branch}}\n    SHA: {{trigger.parameters.revision}}\n    BUILD: {{trigger.parameters.build}}```"

--- a/rules/st2cd_slack_webui_pkg.yaml
+++ b/rules/st2cd_slack_webui_pkg.yaml
@@ -9,7 +9,7 @@
             pattern: "st2cd.webui_pkg"
             type: "equals"
     action:
-        ref: "slack.post_message"
+        ref: "slack.chat.postMessage"
         parameters:
-            message: "```[{{trigger.action_name}} - {{trigger.parameters.environment}}: {{trigger.status.upper()}}]\n    DL_HOST: {{trigger.parameters.dl_server}}\n    BRANCH: {{trigger.parameters.branch}}\n    BUILD: {{trigger.parameters.build}}```"
+            text: "```[{{trigger.action_name}} - {{trigger.parameters.environment}}: {{trigger.status.upper()}}]\n    DL_HOST: {{trigger.parameters.dl_server}}\n    BRANCH: {{trigger.parameters.branch}}\n    BUILD: {{trigger.parameters.build}}```"
     pack: "st2cd"


### PR DESCRIPTION
This will make st2cd repo consistent with the https://github.com/stackstorm/st2ci about using the same Slack action.