### PR TITLE
Fix run_e2e_tests to skip Mistral and properly not-skip everything else

### DIFF
--- a/actions/workflows/st2_e2e_tests.yaml
+++ b/actions/workflows/st2_e2e_tests.yaml
@@ -74,7 +74,7 @@ tasks:
   check_if_mistral_is_available:
     action: core.noop
     next:
-      - when: <% succeeded() and ('u18' in ctx().host_fqdn.toLower() or 'rhel8' in ctx().host_fqdn.toLower() or 'centos8' in ctx().host_fqdn.toLower()) %>
+      - when: <% succeeded() and ('u18' in ctx().host_fqdn.toLower() or 'el8' in ctx().host_fqdn.toLower() or 'centos8' in ctx().host_fqdn.toLower()) %>
         do:
           # Mistral is not available on Ubuntu Bionic or RHEL 8, so skip them
           - run_inquiry_tests

--- a/actions/workflows/st2_e2e_tests_test_inquiry.yaml
+++ b/actions/workflows/st2_e2e_tests_test_inquiry.yaml
@@ -28,11 +28,11 @@ tasks:
   check_if_mistral_is_available:
     action: core.noop
     next:
-      - when: <% succeeded() and ('u18' in ctx().host_fqdn.toLower() or 'rhel8' in ctx().host_fqdn.toLower() or 'centos8' in ctx().host_fqdn.toLower()) %>
+      - when: <% succeeded() and ('u18' in ctx().host_fqdn.toLower() or 'el8' in ctx().host_fqdn.toLower() or 'centos8' in ctx().host_fqdn.toLower()) %>
         do:
           # Mistral is not available on Ubuntu Bionic or RHEL8, so skip Mistral tests
           - noop
-      - when: <% succeeded() and (not 'u18' in ctx().host_fqdn.toLower()) and (not 'rhel8' in ctx().host_fqdn.toLower()) and (not 'centos8' in ctx().host_fqdn.toLower()) %>
+      - when: <% succeeded() and (not 'u18' in ctx().host_fqdn.toLower()) and (not 'el8' in ctx().host_fqdn.toLower()) and (not 'centos8' in ctx().host_fqdn.toLower()) %>
         do:
           - test_inquiry_mistral
   test_inquiry_mistral:


### PR DESCRIPTION
This bug is pretty straightforward. One `when` condition is incorrectly checking for `rhel8` in the host FQDN, while the other `when` condition is correctly checking for `el8` in the host FQDN.