### PR TITLE
Add missing jq for EL8

### DIFF
--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -49,7 +49,7 @@ if [[ -n "$RHTEST" ]]; then
         sudo yum install -y python-pip jq
     else
         # For RHEL/CentOS 8 and above
-        sudo yum install -y python3-pip wget
+        sudo yum install -y python3-pip wget jq
         PIP="pip3"
     fi
 


### PR DESCRIPTION
EL8 st2docs tests are failing because of missing `jq`
```
not ok 19 can run packs.setup_virtualenv for a pack downloaded in previous step # setup: 0s, test: 9s, teardown: 0s
# (from function `assert_success' in file docs/../test_helpers/bats-assert/src/assert.bash, line 114,
#  in test file docs/test_integration_packs_doc.bats, line 76)
#   `assert_success' failed with status 127
# 
# -- command failed --
# status : 127
# output (3 lines):
#   /usr/local/libexec/bats-core/bats-exec-test: line 62: jq: command not found
#   Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
#   BrokenPipeError: [Errno 32] Broken pipe
# --
```