### PR TITLE
Fix 3.2.0 build failure due to missing version update for st2 init files

### DIFF
--- a/actions/st2_prep_release_for_st2.sh
+++ b/actions/st2_prep_release_for_st2.sh
@@ -77,6 +77,12 @@ git checkout -b ${BRANCH} origin/master
 COMMON_INIT_FILES=(
     "st2common/st2common/__init__.py"
     "st2client/st2client/__init__.py"
+    "st2actions/st2actions/__init__.py"
+    "st2api/st2api/__init__.py"
+    "st2auth/st2auth/__init__.py"
+    "st2debug/st2debug/__init__.py"
+    "st2reactor/st2reactor/__init__.py"
+    "st2stream/st2stream/__init__.py"
 )
 
 # Add all the runners


### PR DESCRIPTION
Change in st2 https://github.com/StackStorm/st2/pull/4751 made every st2 component behave like an independent python package, however we failed to update all the release workflows to support that.

This resulted in keeping old `3.2dev` versions for some of st2 components when automation should change it to `3.2.0`.

https://github.com/StackStorm/st2/blob/522ef49eb3d6cfc8ff09cf4342cc941adb46e4af/st2api/st2api/__init__.py#L15