### PR TITLE
Disable the daily scheduled jobs for checking enterprise packages

### DIFF
--- a/rules/st2_pkg_test_stable_rhel7_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_rhel7_enterprise.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_test_stable_rhel7_enterprise
 pack: st2cd
 description: Test stable packages
-enabled: true
+enabled: false
 
 trigger:
   type: core.st2.CronTimer

--- a/rules/st2_pkg_test_stable_rhel8_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_rhel8_enterprise.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_test_stable_rhel8_enterprise
 pack: st2cd
 description: Test stable packages
-enabled: true
+enabled: false
 
 trigger:
   type: core.st2.CronTimer

--- a/rules/st2_pkg_test_stable_u16_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_u16_enterprise.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_test_stable_u16_enterprise
 pack: st2cd
 description: Test stable packages
-enabled: true
+enabled: false
 
 trigger:
   type: core.st2.CronTimer

--- a/rules/st2_pkg_test_stable_u18_enterprise.yaml
+++ b/rules/st2_pkg_test_stable_u18_enterprise.yaml
@@ -2,7 +2,7 @@
 name: st2_pkg_test_stable_u18_enterprise
 pack: st2cd
 description: Test stable packages
-enabled: true
+enabled: false
 
 trigger:
   type: core.st2.CronTimer


### PR DESCRIPTION
Extreme Networks is winding down support for enterprise packages. The daily scheduled CI jobs to check enterprise packages will be disabled.