### PR TITLE
Enhanced error message when st2_prep_release is run twice

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+# Changelog
+
+## 0.1.3
+
+Added descriptive error message to `st2cd.st2_prep_release_for_st2` in case that workflow
+is run twice. This is in hope that it helps the next person who tries to run this workflow
+and is confused about it erroring and not being idempotent.
+
+Contributed by Nick Maludy (@nmaludy)
+
 ## 0.1.2 
 
 Removed EL6 and added EL8

--- a/actions/st2_prep_release_for_st2.sh
+++ b/actions/st2_prep_release_for_st2.sh
@@ -16,7 +16,7 @@ PUSH=0
 BRANCH_EXISTS=`git ls-remote --heads ${GIT_REPO} | grep refs/heads/${BRANCH} || true`
 
 if [[ ! -z "${BRANCH_EXISTS}" ]]; then
-    >&2 echo "ERROR: Branch ${BRANCH} already exist in ${GIT_REPO}."
+    >&2 echo "ERROR: Branch ${BRANCH} already exist in ${GIT_REPO}. If you are trying to include changes made after running the 'prep release' step, then simply merge your changes into the existing release branch ${BRANCH}. This step creates release branches (vX.Y) and changelogs across the various repos, and during the release you can incorporate changes/fixes into those release branches. Changes must be merged into these release branches in order to be included in the final release."
     exit 1
 fi
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : st2cd
 description : Continuous delivery pipeline at StackStorm
-version : 0.1.3
+version : 0.1.4
 author : st2-dev
 email : info@stackstorm.com


### PR DESCRIPTION
When working on the `3.3` release i accidentally ran the `st2_prep_release` action too soon (going to fix this by editing the Release process Wiki). Coming back to this a week or so later, i thought about running this action again and came across a bad error message that told me what was wrong, but didn't tell me what i should be doing instead.

I've edited the error message with some helpful guidance to the next person performing a release, so hopefully they won't stub their toe like i did.