### PR TITLE
Capitalize the S's in StackStorm since project names are case-sensitive

### DIFF
--- a/actions/workflows/st2_finalize_release.yaml
+++ b/actions/workflows/st2_finalize_release.yaml
@@ -131,7 +131,7 @@ tasks:
     action: circle_ci.run_build
     input:
       project: st2apidocs
-      username: stackstorm
+      username: StackStorm
       branch: master
       build_parameters:
         ST2_BRANCH: <% 'v' + ctx().major_minor_version %>


### PR DESCRIPTION
This was broken in the latest release.