### PR TITLE
Add TODO for improving the vagrant_tag_release action

### DIFF
--- a/actions/vagrant_tag_release.sh
+++ b/actions/vagrant_tag_release.sh
@@ -60,6 +60,10 @@ if [[ -z "${TAGGED}" ]]; then
     git tag -a ${TAGGED_VERSION} -m "Creating tag ${TAGGED_VERSION} for branch ${BRANCH}"
     git push origin ${TAGGED_VERSION} -q
 else
+    # TODO: Have this script figure out if the new tag is pointing to the same
+    #       commit as the old tag. If they're pointing to the same commit,
+    #       nothing needs to be done. If they're pointing to different commits,
+    #       then we should update the existing tag to point to the newer commit.
     echo "Tag ${TAGGED_VERSION} already exists."
 fi
 


### PR DESCRIPTION
The release process tweaks the changelog for the StackStorm/packer-st2 project and creates and pushes a new tag to match the StackStorm version.

When the changelog changes are pushed, a CircleCI build is started. However, the `vagrant_tag_release` action never checks for the status of the CircleCI build. If the CircleCI build fails, a Vagrant image will _not_ actually be created for that StackStorm release. That means that the release manager will need to make a PR to the packer-st2, and merge changes, but the new tag won't ever be updated to point to the fixed commit.

The script is smart enough to skip updating the changelog if it already contains the version blurb, but the script will simply bail out if the tag already exists.

Instead the script should update the tag to point to the latest commit. It might be prudent to hide this behavior behind a `force` parameter or something like that.

This PR adds a TODO message to do exactly that. This might be a good task for a community member to get familiar with this repo.