### PR TITLE
Fix StackStorm capitalization

### DIFF
--- a/actions/workflows/bwc_stage_release_packages.yaml
+++ b/actions/workflows/bwc_stage_release_packages.yaml
@@ -13,7 +13,7 @@ input:
       UBUNTU18: u18
 
 vars:
-  - username: stackstorm
+  - username: StackStorm
 
 tasks:
   init:

--- a/actions/workflows/bwc_stage_release_packages.yaml
+++ b/actions/workflows/bwc_stage_release_packages.yaml
@@ -4,13 +4,14 @@ description: Stage bwc packages for release.
 input:
   - version
   - projects
-  - username: stackstorm
   - wait
   - distros:
       RHEL7: el7
       RHEL8: el8
       UBUNTU16: u16
       UBUNTU18: u18
+vars:
+  - username: stackstorm
 tasks:
   init:
     action: core.local

--- a/actions/workflows/bwc_stage_release_packages.yaml
+++ b/actions/workflows/bwc_stage_release_packages.yaml
@@ -1,6 +1,7 @@
 ---
 version: '1.0'
 description: Stage bwc packages for release.
+
 input:
   - version
   - projects
@@ -10,8 +11,10 @@ input:
       RHEL8: el8
       UBUNTU16: u16
       UBUNTU18: u18
+
 vars:
   - username: stackstorm
+
 tasks:
   init:
     action: core.local

--- a/actions/workflows/st2_stage_release_packages.yaml
+++ b/actions/workflows/st2_stage_release_packages.yaml
@@ -1,6 +1,7 @@
 ---
 version: '1.0'
 description: Stage st2 packages for release.
+
 input:
   - version
   - projects
@@ -10,8 +11,10 @@ input:
       RHEL8: el8
       UBUNTU16: u16
       UBUNTU18: u18
+
 vars:
   - username: stackstorm
+
 tasks:
   init:
     action: core.local

--- a/actions/workflows/st2_stage_release_packages.yaml
+++ b/actions/workflows/st2_stage_release_packages.yaml
@@ -13,7 +13,7 @@ input:
       UBUNTU18: u18
 
 vars:
-  - username: stackstorm
+  - username: StackStorm
 
 tasks:
   init:

--- a/actions/workflows/st2_stage_release_packages.yaml
+++ b/actions/workflows/st2_stage_release_packages.yaml
@@ -10,6 +10,8 @@ input:
       RHEL8: el8
       UBUNTU16: u16
       UBUNTU18: u18
+vars:
+  - username: stackstorm
 tasks:
   init:
     action: core.local
@@ -26,7 +28,7 @@ tasks:
       items: project in <% ctx().projects %>
     action: circle_ci.run_build
     input:
-      project: stackstorm/<% item(project) %>
+      project: <% ctx().username %>/<% item(project) %>
       branch: <% ctx().branch %>
     next:
       - when: <% succeeded() and (ctx().wait) %>
@@ -39,5 +41,5 @@ tasks:
       items: package_job in <% ctx().package_jobs %>
     action: st2cd.wait_for_package
     input:
-      project: stackstorm/<% item(package_job)[0] %>
+      project: <% ctx().username %>/<% item(package_job)[0] %>
       build_number: <% str(item(package_job)[1]) %>

--- a/rules/sync_api_docs_on_st2_commits.yaml
+++ b/rules/sync_api_docs_on_st2_commits.yaml
@@ -19,7 +19,7 @@ action:
     ref: circle_ci.run_build
     parameters:
       project: st2apidocs
-      username: stackstorm
+      username: StackStorm
       branch: master
       build_parameters:
           ST2_BRANCH: "{{ trigger.body.ref.split('/')[2] }}"


### PR DESCRIPTION
During the 3.3.0 release, we ran into issues where the CircleCI API didn't use to be case-sensitive but it is now. As such, we need to properly capitalize "StackStorm" when we specify the `username` parameter to `circle_ci.run_build` tasks.

Additionally, this issue also affects the `st2cd.sync_api_docs_on_st2_commits` rule during normal development.

This PR implements that change in the rule and the workflows to stage and release packages, and pulls the username into a workflow variable so we don't need to repeat ourselves.

Bonus: I also spaced out the workflow root keys a bit to improve the readability.