### PR TITLE
Use Python 3 to create virtualenvs

### DIFF
--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -127,7 +127,7 @@ if [ -f st2tests/conf/st2.ci.conf ]; then
 fi
 
 sudo cp -R /usr/share/doc/st2/examples /opt/stackstorm/packs/
-st2 run packs.setup_virtualenv packs=examples,tests,asserts,fixtures,webui,chatops_tests
+st2 run packs.setup_virtualenv python3=true packs=examples,tests,asserts,fixtures,webui,chatops_tests
 st2ctl reload --register-all
 
 cd st2tests

--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -131,7 +131,7 @@ st2 run packs.setup_virtualenv packs=examples,tests,asserts,fixtures,webui,chato
 st2ctl reload --register-all
 
 cd st2tests
-virtualenv --no-download venv
+python3 -m venv venv
 . venv/bin/activate
 ${PIP} install -r test-requirements.txt
 

--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -43,10 +43,10 @@ if [[ -n "$RHTEST" ]]; then
 
     if [[ "$RHVERSION" -eq 7 ]]; then
         # For RHEL/CentOS 7
-        sudo yum install -y python-pip jq bats
+        sudo yum install -y bats jq python3-pip python3-virtualenv
     else
         # For RHEL/CentOS 8 and above
-        sudo yum install -y python3-pip wget jq 
+        sudo yum install -y jq python3-pip python3-virtualenv wget
         PIP="pip3"
         # bats not available in epel for EL 8, Install from npm
         sudo npm install --global bats
@@ -63,7 +63,7 @@ elif [[ -n "$DEBTEST" ]]; then
       sudo systemctl restart mongod
     fi
 
-    sudo apt-get -q -y install build-essential jq python-pip python-dev wget
+    sudo apt-get -q -y install build-essential jq python3-pip python3-dev python3-venv wget
 
     # Remove bats-core if it already exists (this happens when test workflows
     # are re-run on a server when tests are debugged)

--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -133,7 +133,7 @@ st2ctl reload --register-all
 cd st2tests
 python3 -m venv venv
 . venv/bin/activate
-${PIP} install -r test-requirements.txt
+${PIP} install -r test-requirements.txt  # TODO: This should eventually use python3 -m pip
 
 
 # Restart st2 primarily reload the keyvalue configuration

--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -130,11 +130,7 @@ sudo cp -R /usr/share/doc/st2/examples /opt/stackstorm/packs/
 st2 run packs.setup_virtualenv packs=examples,tests,asserts,fixtures,webui,chatops_tests
 st2ctl reload --register-all
 
-# Robotframework requirements
 cd st2tests
-sudo ${PIP} install --upgrade "pip>=9.0,<9.1"
-sudo ${PIP} install --upgrade "virtualenv==15.1.0"
-
 virtualenv --no-download venv
 . venv/bin/activate
 ${PIP} install -r test-requirements.txt


### PR DESCRIPTION
This tweaks `setup_e2e_tests.sh` to install Python 3 pip and virtualenv packages for both RHEL 7 & 8 and Ubuntu tests.