### PR TITLE
Remove st2debug component, as only contained submit-debug-info

### DIFF
--- a/actions/check_pkgs.yaml
+++ b/actions/check_pkgs.yaml
@@ -12,5 +12,5 @@
       position: 0
     packages:
       type: "string"
-      default: "st2common st2reactor st2actions st2api st2stream st2auth st2debug"
+      default: "st2common st2reactor st2actions st2api st2stream st2auth"
       position: 1

--- a/actions/scripts/upgrade_checks.sh
+++ b/actions/scripts/upgrade_checks.sh
@@ -12,7 +12,7 @@ if [ $# -ne 2 ]; then
     exit 1
 fi
 
-PACKAGES=(st2actions st2api st2auth st2common st2debug st2reactor python-st2client)
+PACKAGES=(st2actions st2api st2auth st2common st2reactor python-st2client)
 SERVICE_NAMES=(st2actionrunner st2notifier st2resultstracker st2sensorcontainer st2rulesengine st2api st2workflowengine)
 
 function verify_debian_package_version_is_installed() {

--- a/actions/st2_chg_ver_for_st2.sh
+++ b/actions/st2_chg_ver_for_st2.sh
@@ -53,7 +53,6 @@ COMMON_INIT_FILES=(
     "st2actions/st2actions/__init__.py"
     "st2api/st2api/__init__.py"
     "st2auth/st2auth/__init__.py"
-    "st2debug/st2debug/__init__.py"
     "st2reactor/st2reactor/__init__.py"
     "st2stream/st2stream/__init__.py"
 )

--- a/actions/st2_prep_release_for_st2.sh
+++ b/actions/st2_prep_release_for_st2.sh
@@ -80,7 +80,6 @@ COMMON_INIT_FILES=(
     "st2actions/st2actions/__init__.py"
     "st2api/st2api/__init__.py"
     "st2auth/st2auth/__init__.py"
-    "st2debug/st2debug/__init__.py"
     "st2reactor/st2reactor/__init__.py"
     "st2stream/st2stream/__init__.py"
 )

--- a/actions/workflows/st2_upgrade_ubuntu16.yaml
+++ b/actions/workflows/st2_upgrade_ubuntu16.yaml
@@ -15,7 +15,7 @@
       params:
         hosts: "{{hostname}}"
         act: "install -y -o Dpkg::Options::=\"--force-confnew\""
-        packages: "st2common st2reactor st2actions st2api st2stream st2auth st2debug"
+        packages: "st2common st2reactor st2actions st2api st2stream st2auth"
         timeout: 300
       on-success: "upgrade_st2client"
     -


### PR DESCRIPTION
Companion to StackStorm/st2#5103.
The only item in st2debug component is the submit-debug-info component, so when this is removed the st2debug component also is removed. So remove it from the components.