### PR TITLE
Update st2_chg_ver_for_st2.sh to use double quotes

### DIFF
--- a/actions/st2_chg_ver_for_st2.sh
+++ b/actions/st2_chg_ver_for_st2.sh
@@ -71,12 +71,15 @@ do
         exit 1
     fi
 
-    VERSION_STR="__version__ = '${VERSION}'"
+    # The black lint checker forces us to use double quotes for these
+    # but we check for both single quotes and double quotes to ensure
+    # that we find them all
+    VERSION_STR="__version__ = ['\"]${VERSION}['\"]"
 
     VERSION_STR_MATCH=`grep "${VERSION_STR}" ${INIT_FILE} || true`
     if [[ -z "${VERSION_STR_MATCH}" ]]; then
         echo "Setting version in ${INIT_FILE} to ${VERSION}..."
-        sed -i -e "s/\(__version__ = \).*/\1'${VERSION}'/" ${INIT_FILE}
+        sed -i -e "s/\(__version__ = \).*/\1\"${VERSION}\"/" ${INIT_FILE}
 
         VERSION_STR_MATCH=`grep "${VERSION_STR}" ${INIT_FILE} || true`
         if [[ -z "${VERSION_STR_MATCH}" ]]; then


### PR DESCRIPTION
GHA [CI is failing](https://github.com/StackStorm/st2/runs/2985686600?check_suite_focus=true) because our [release scripts](https://github.com/StackStorm/st2cd/blob/da810fdfa353a976743b8a16d70f34d63c613957/actions/st2_chg_ver_for_st2.sh#L79) insert single quotes instead of double quotes:

```bash
sed -i -e "s/\(__version__ = \).*/\1'${VERSION}'/" ${INIT_FILE}
#                                   ^          ^
```

But black forces us to use double quotes:

```
================== black-check ====================

# st2 components
===========================================================
Running black on st2actions
===========================================================
would reformat /home/runner/work/st2/st2/st2actions/st2actions/__init__.py
Oh no! 💥 💔 💥
1 file would be reformatted, 59 files would be left unchanged.
make: *** [Makefile:372: .black-check] Error 1
Script done, file is typescript
Error: Process completed with exit code 2.
```

Running black manually:

```diff
diff --git a/st2actions/st2actions/__init__.py b/st2actions/st2actions/__init__.py
index 2e5ec8277..18f4135fa 100644
--- a/st2actions/st2actions/__init__.py
+++ b/st2actions/st2actions/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.

-__version__ = '3.6dev'
+__version__ = "3.6dev"
diff --git a/st2api/st2api/__init__.py b/st2api/st2api/__init__.py
index 2e5ec8277..18f4135fa 100644
--- a/st2api/st2api/__init__.py
+++ b/st2api/st2api/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.

-__version__ = '3.6dev'
+__version__ = "3.6dev"
diff --git a/st2auth/st2auth/__init__.py b/st2auth/st2auth/__init__.py
index 2e5ec8277..18f4135fa 100644
--- a/st2auth/st2auth/__init__.py
+++ b/st2auth/st2auth/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.

-__version__ = '3.6dev'
+__version__ = "3.6dev"
diff --git a/st2client/st2client/__init__.py b/st2client/st2client/__init__.py
index 2e5ec8277..18f4135fa 100644
--- a/st2client/st2client/__init__.py
+++ b/st2client/st2client/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.

-__version__ = '3.6dev'
+__version__ = "3.6dev"
diff --git a/st2common/st2common/__init__.py b/st2common/st2common/__init__.py
index 2e5ec8277..18f4135fa 100644
--- a/st2common/st2common/__init__.py
+++ b/st2common/st2common/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.

-__version__ = '3.6dev'
+__version__ = "3.6dev"
diff --git a/st2reactor/st2reactor/__init__.py b/st2reactor/st2reactor/__init__.py
index 2e5ec8277..18f4135fa 100644
--- a/st2reactor/st2reactor/__init__.py
+++ b/st2reactor/st2reactor/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.

-__version__ = '3.6dev'
+__version__ = "3.6dev"
diff --git a/st2stream/st2stream/__init__.py b/st2stream/st2stream/__init__.py
index 2e5ec8277..18f4135fa 100644
--- a/st2stream/st2stream/__init__.py
+++ b/st2stream/st2stream/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.

-__version__ = '3.6dev'
+__version__ = "3.6dev"
diff --git a/st2tests/st2tests/__init__.py b/st2tests/st2tests/__init__.py
index 6e50763e0..da3a41132 100644
--- a/st2tests/st2tests/__init__.py
+++ b/st2tests/st2tests/__init__.py
@@ -30,4 +30,4 @@ __all__ = [
     "WorkflowTestCase",
 ]

-__version__ = '3.6dev'
+__version__ = "3.6dev"
```

This PR updates our release scripts to use double quotes, and updates the detection regex to allow for either single quotes or double quotes, just in case it is used against an older branch or fork of the `st2` codebase.

Apologies for the gnarly branch name.

The corresponding PR to fix the existing code in the `st2` codebase is StackStorm/st2#5299.