### PR TITLE
Fix logic that determines whether to add new key or amend existing key

### DIFF
--- a/actions/setup_e2e_tests.sh
+++ b/actions/setup_e2e_tests.sh
@@ -101,16 +101,16 @@ if [[ ! -e "${CRYPTO_KEY_FILE}" ]]; then
     sudo chgrp st2packs ${CRYPTO_KEY_FILE}
 fi
 
-if ! grep -qE "encryption_key_path[[:space:]]*=[[:space:]]*${CRYPTO_KEY_FILE}" ${ST2_CONF}; then
+if ! grep -qE "encryption_key_path[[:space:]]*=[[:space:]]*" ${ST2_CONF}; then
     # Add a new keyvalue.encryption_key_path
     # This looks overly complicated...
     sudo bash -c "cat <<keyvalue_options >>${ST2_CONF}
 [keyvalue]
 encryption_key_path = ${CRYPTO_KEY_FILE}
 keyvalue_options"
-elif ! grep -qE "encryption_key_path[[:space:]]*=[[:space:]]*" ${ST2_CONF}; then
+elif ! grep -qE "encryption_key_path[[:space:]]*=[[:space:]]*${CRYPTO_KEY_FILE}" ${ST2_CONF}; then
     # If keyvalue.encryption_key_path exists, then modify it
-    sed -i "s|^encryption_key_path[[:space:]]*=[[:space:]]*[^[:space:]]\{1,\}$|encryption_key_path = ${CRYPTO_KEY_FILE}|" ${ST2_CONF}
+    sudo sed -i "s|^encryption_key_path[[:space:]]*=[[:space:]]*[^[:space:]]\{1,\}$|encryption_key_path = ${CRYPTO_KEY_FILE}|" ${ST2_CONF}
 fi
 
 # Reload required for testing st2 upgrade


### PR DESCRIPTION
With the introduction of https://github.com/StackStorm/st2-packages/pull/706 the systemd generators will fail to create the st2api.socket etc files if there are duplicate keys in st2.conf.

When setup_e2e_tests.sh is run it was adding duplicating encryption_key_path keys, as it had its if /elif the wrong way round - so if the key was there with different value it woudl always add a new value instead of amending the old one.

This causes the E2E tests to break.