### PR TITLE
Fix win e2e test - update the location for WinRM powershell setup script

### DIFF
--- a/actions/workflows/create_vm_windows.yaml
+++ b/actions/workflows/create_vm_windows.yaml
@@ -19,7 +19,7 @@ vars:
   - wait_for_winrm_count: 0
   - ec2_instance_password: ""
   - ec2_instance_id:
-  - ec2_instance_user_data: "<powershell>\n#Setup for TLS v1.2\n[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;\n# download the script\n(New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1', './ConfigureRemotingForAnsible.ps1')\n# execute the script\n./ConfigureRemotingForAnsible.ps1\n</powershell>"
+  - ec2_instance_user_data: "<powershell>\n#Setup for TLS v1.2\n[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;\n# download the script\n(New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/ansible/ansible/stable-2.12/examples/scripts/ConfigureRemotingForAnsible.ps1', './ConfigureRemotingForAnsible.ps1')\n# execute the script\n./ConfigureRemotingForAnsible.ps1\n</powershell>"
   - vm_info:
       id:
       private_ip_address:


### PR DESCRIPTION
Powershell script to setup `winrm` used when starting a EC2 instance is not available anymore by its old location (`404`).
It was referenced here https://docs.ansible.com/archive/ansible/2.5/user_guide/windows_setup.html

Update the location and fix the mystery with windows e2e tests failing to run due to winrm timeout.
