### PR TITLE
Make Pypi upload step idempotent

### DIFF
--- a/actions/pypi_upload.sh
+++ b/actions/pypi_upload.sh
@@ -86,7 +86,7 @@ sudo pip install --upgrade "six==1.11.0"
 
 python setup.py sdist bdist_wheel
 
-twine upload dist/* -r pypi
+twine upload --skip-existing dist/* -r pypi
 if [[ $? != 0 ]]; then exit 1; fi
 
 


### PR DESCRIPTION
During the v3.8.1 patch release, re-running `st2cd.st2_finalize_release` fails because `pypi_upload.sh` was already ran successfully before and package exist:
```
HTTPError: 400 Client Error: File already exists. See https://pypi.org/help/#file-name-reuse for more information. for url: https://upload.pypi.org/legacy/",
```

Make this task idempotent and not failing if the package is already in the index by adding `--skip-existing` flag to `twine` that used for pypi package publishing.